### PR TITLE
Fix npm vulnerability warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@swc/core": ">=1.0.12"
   },
   "devDependencies": {
+    "@swc/core": "^1.0.12",
     "@types/convert-source-map": "^1.5.1",
     "@types/fs-readdir-recursive": "^1.0.0",
     "@types/glob": "^7.1.1",
@@ -37,8 +38,7 @@
     "@types/mkdirp": "^0.5.2",
     "@types/node": "^10.12.18",
     "@types/slash": "^2.0.0",
-    "jest": "^23.6.0",
-    "@swc/core": "^1.0.12",
+    "jest": "^24.1.0",
     "typescript": "^3.2.2"
   },
   "dependencies": {


### PR DESCRIPTION
When running `npm install` this message was displayed:

> found 62 low severity vulnerabilities
>   run `npm audit fix` to fix them, or `npm audit` for details

By updating `jest` swc/cli no longer depends on known vulnerable
packages.

The change to package.json was made entirely by this command:
```
npm audit fix --force
```

As `jest` doesn't appear to be used, we could also fix the vulnerability
warning by not depending on jest.