### PR TITLE
feat: add CLI option for suppressing compilation output

### DIFF
--- a/src/swc/dir.ts
+++ b/src/swc/dir.ts
@@ -10,7 +10,7 @@ import * as swc from "@swc/core";
 import * as util from "./util";
 import { CliOptions } from "./options";
 
-export default async function({
+export default async function ({
   cliOptions,
   swcOptions
 }: {
@@ -112,7 +112,7 @@ export default async function({
           try {
             const written = await handleFile(src, dirname);
             if (written) count += 1;
-          } catch (e) {}
+          } catch (e) { }
         })
       );
 
@@ -135,16 +135,17 @@ export default async function({
     compiledFiles += await handle(filename);
   }
 
-  console.log(
-    `Successfully compiled ${compiledFiles} ${
-      compiledFiles !== 1 ? "files" : "file"
-    } with swc.`
-  );
+  if (!cliOptions.quiet) {
+    console.log(
+      `Successfully compiled ${compiledFiles} ${compiledFiles !== 1 ? "files" : "file"
+      } with swc.`
+    );
+  }
 
   if (cliOptions.watch) {
     const chokidar = util.requireChokidar();
 
-    filenames.forEach(function(filenameOrDir) {
+    filenames.forEach(function (filenameOrDir) {
       const watcher = chokidar.watch(filenameOrDir, {
         persistent: true,
         ignoreInitial: true,
@@ -154,8 +155,8 @@ export default async function({
         }
       });
 
-      ["add", "change"].forEach(function(type) {
-        watcher.on(type, function(filename: string) {
+      ["add", "change"].forEach(function (type) {
+        watcher.on(type, function (filename: string) {
           handleFile(
             filename,
             filename === filenameOrDir

--- a/src/swc/options.ts
+++ b/src/swc/options.ts
@@ -39,6 +39,8 @@ commander.option(
 
 commander.option("-w, --watch", "Recompile files on changes");
 
+commander.option("-q, --quiet", "Suppress compilation output");
+
 // General source map formatting.
 commander.option("-s, --source-maps [true|false|inline|both]", "", booleanify);
 commander.option(
@@ -132,6 +134,7 @@ export interface CliOptions {
   readonly copyFiles: boolean;
   readonly includeDotfiles: boolean;
   readonly deleteDirOnStart: boolean;
+  readonly quiet: boolean;
 }
 
 export default function parserArgs(args: string[]) {
@@ -235,7 +238,8 @@ export default function parserArgs(args: string[]) {
     relative: !!opts.relative,
     copyFiles: !!opts.copyFiles,
     includeDotfiles: !!opts.includeDotfiles,
-    deleteDirOnStart: !!opts.deleteDirOnStart
+    deleteDirOnStart: !!opts.deleteDirOnStart,
+    quiet: !!opts.quiet
   };
 
   return {


### PR DESCRIPTION
I've added an option that allows for the suppression of console output when compiling a directory. This is especially useful for scripting purposes, for instance when you want to compile a batch of files without seeing lots of messages in `stdout`.