### PR TITLE
Add "--log-watch-compilation" option and exit with code 1 if compilation failed

### DIFF
--- a/src/swc/dir.ts
+++ b/src/swc/dir.ts
@@ -157,14 +157,23 @@ export default async function ({
 
       ["add", "change"].forEach(function (type) {
         watcher.on(type, function (filename: string) {
+          const start = process.hrtime()
+
           handleFile(
             filename,
             filename === filenameOrDir
               ? path.dirname(filenameOrDir)
               : filenameOrDir
-          ).catch(err => {
-            console.error(err);
-          });
+          )
+            .then(ok => {
+              if (cliOptions.logWatchCompilation && ok) {
+                const [seconds, nanoseconds] = process.hrtime(start);
+                const ms = (seconds * 1000000000 + nanoseconds) / 1000000;
+                const name = path.basename(filename);
+                console.log(`Compiled ${name} in ${ms.toFixed(2)}ms`);
+              }
+            })
+            .catch(console.error);
         });
       });
     });

--- a/src/swc/dir.ts
+++ b/src/swc/dir.ts
@@ -95,14 +95,17 @@ export default async function ({
     return written;
   }
 
-  async function handle(filenameOrDir: string) {
-    if (!fs.existsSync(filenameOrDir)) return 0;
+  type HandleResult = { succeeded: number; failed: number }
+
+  async function handle(filenameOrDir: string): Promise<HandleResult> {
+    if (!fs.existsSync(filenameOrDir)) return { succeeded: 0, failed: 0 };
     const stat = fs.statSync(filenameOrDir);
 
     if (stat.isDirectory()) {
       const dirname = filenameOrDir;
 
-      let count = 0;
+      let succeeded = 0;
+      let failed = 0;
 
       const files = util.readdir(dirname, cliOptions.includeDotfiles);
 
@@ -111,17 +114,23 @@ export default async function ({
           const src = path.join(dirname, filename);
           try {
             const written = await handleFile(src, dirname);
-            if (written) count += 1;
-          } catch (e) { }
+            if (written) succeeded += 1;
+            else failed += 1;
+          } catch (e) {
+            failed += 1;
+          }
         })
       );
 
-      return count;
+      return { succeeded, failed };
     } else {
       const filename = filenameOrDir;
       const written = await handleFile(filename, path.dirname(filename));
 
-      return written ? 1 : 0;
+      return {
+        succeeded: written ? 1 : 0,
+        failed: written ? 0 : 1
+      };
     }
   }
 
@@ -131,15 +140,28 @@ export default async function ({
   mkdirpSync(cliOptions.outDir);
 
   let compiledFiles = 0;
+  let failedFiles = 0;
+
   for (const filename of cliOptions.filenames) {
-    compiledFiles += await handle(filename);
+    const { succeeded, failed } = await handle(filename);
+    compiledFiles += succeeded
+    failedFiles += failed
   }
 
   if (!cliOptions.quiet) {
-    console.log(
-      `Successfully compiled ${compiledFiles} ${compiledFiles !== 1 ? "files" : "file"
-      } with swc.`
-    );
+    if (compiledFiles > 0) {
+      console.log(
+        `Successfully compiled ${compiledFiles} ${compiledFiles !== 1 ? "files" : "file"
+        } with swc.`
+      );
+    }
+
+    if (failedFiles > 0) {
+      const error = `Failed to compile ${failedFiles} ${failedFiles !== 1 ? "files" : "file"
+        } with swc.`
+      if (!cliOptions.watch) throw new Error(error)
+      else console.error(error)
+    }
   }
 
   if (cliOptions.watch) {

--- a/src/swc/options.ts
+++ b/src/swc/options.ts
@@ -86,6 +86,11 @@ commander.option(
   collect
 );
 
+commander.option(
+  "--log-watch-compilation",
+  "Log a message when a watched file is successfully compiled"
+);
+
 commander.version(
   `@swc/cli: ${pkg.version}
 @swc/core: ${swcCoreVersion}`
@@ -135,6 +140,7 @@ export interface CliOptions {
   readonly includeDotfiles: boolean;
   readonly deleteDirOnStart: boolean;
   readonly quiet: boolean;
+  readonly logWatchCompilation: boolean;
 }
 
 export default function parserArgs(args: string[]) {
@@ -166,6 +172,8 @@ export default function parserArgs(args: string[]) {
     if (!filenames.length) {
       errors.push("--watch requires filenames");
     }
+  } else if (commander.logWatchCompilation) {
+    errors.push("--log-watch-compilation requires --watch")
   }
 
   if (
@@ -239,7 +247,8 @@ export default function parserArgs(args: string[]) {
     copyFiles: !!opts.copyFiles,
     includeDotfiles: !!opts.includeDotfiles,
     deleteDirOnStart: !!opts.deleteDirOnStart,
-    quiet: !!opts.quiet
+    quiet: !!opts.quiet,
+    logWatchCompilation: !!opts.logWatchCompilation
   };
 
   return {


### PR DESCRIPTION
Hello

This PR contains 2 new features:

1) A new --log-watch-compilation flag - this will log out a message like this when a file is compiled and watch mode is enabled:
```Compiled amd.js in 9.07ms```.

2) Exit with a code 1 by throwing an error if one or more files failed to compile and watch mode is disabled - this is useful for CI scenarios where you want the whole job to fail if the build fails.

