### PR TITLE
Refactor swc CLI

### DIFF
--- a/examples/spack-node-modules/package.json
+++ b/examples/spack-node-modules/package.json
@@ -10,6 +10,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@swc/cli": "file:../.."
+    "@swc/cli": "file:../..",
+    "path": "^0.12.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
   "devDependencies": {
     "@swc/core": "^1.2.4",
     "@types/convert-source-map": "^1.5.1",
-    "@types/fs-readdir-recursive": "^1.0.0",
     "@types/glob": "^7.1.2",
     "@types/lodash": "^4.14.155",
     "@types/node": "^12.19.16",
@@ -53,7 +52,6 @@
   "dependencies": {
     "commander": "^7.1.0",
     "convert-source-map": "^1.6.0",
-    "fs-readdir-recursive": "^1.1.0",
     "glob": "^7.1.3",
     "lodash": "^4.17.11",
     "slash": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -27,36 +27,36 @@
     "url": "https://github.com/swc-project/cli/issues"
   },
   "homepage": "https://github.com/swc-project/cli#readme",
+  "engines": {
+    "node": ">= 12.13"
+  },
   "peerDependencies": {
-    "@swc/core": "^1.2.4"
+    "@swc/core": "^1.2.4",
+    "chokidar": "^3.0.0"
+  },
+  "peerDependenciesMeta": {
+    "chokidar": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@swc/core": "^1.2.4",
-    "@types/commander": "^2.12.2",
     "@types/convert-source-map": "^1.5.1",
     "@types/fs-readdir-recursive": "^1.0.0",
     "@types/glob": "^7.1.2",
-    "@types/interpret": "^1.1.1",
     "@types/lodash": "^4.14.155",
-    "@types/mkdirp": "^0.5.2",
-    "@types/node": "^10.12.18",
-    "@types/rechoir": "^0.6.1",
-    "@types/slash": "^2.0.0",
+    "@types/node": "^12.19.16",
+    "chokidar": "^3.5.1",
     "jest": "^24.1.0",
-    "typescript": "^3.9.5"
+    "typescript": "~4.1.5"
   },
   "dependencies": {
-    "commander": "^2.19.0",
+    "commander": "^7.1.0",
     "convert-source-map": "^1.6.0",
     "fs-readdir-recursive": "^1.1.0",
     "glob": "^7.1.3",
-    "interpret": "^2.2.0",
     "lodash": "^4.17.11",
-    "mkdirp": "^0.5.1",
-    "output-file-sync": "^2.0.1",
-    "path": "^0.12.7",
-    "rechoir": "^0.7.0",
-    "slash": "^2.0.0",
+    "slash": "3.0.0",
     "source-map": "^0.7.3"
   },
   "bin": {

--- a/src/spack/extensions.ts
+++ b/src/spack/extensions.ts
@@ -1,6 +1,0 @@
-export const extensions = {
-    '.js': '@swc/register',
-    '.jsx': '@swc/register',
-    '.ts': '@swc/register',
-    '.tsx': '@swc/register',
-};

--- a/src/spack/index.ts
+++ b/src/spack/index.ts
@@ -1,6 +1,5 @@
 import { bundle } from '@swc/core';
 import { mkdir, writeFile } from 'fs';
-import { findLastIndex } from 'lodash';
 import { basename, dirname, extname, join, relative } from 'path'
 import { promisify } from 'util';
 

--- a/src/spack/options.ts
+++ b/src/spack/options.ts
@@ -3,9 +3,6 @@ import { BundleOptions, compileBundleOptions } from "@swc/core/spack";
 import commander from "commander";
 import * as path from 'path';
 
-import { prepare } from 'rechoir'
-import { extensions } from './extensions';
-
 const pkg = require("../../package.json");
 
 export interface SpackCliOptions {
@@ -20,7 +17,6 @@ commander.option("--mode <development | production | none>", "Mode to use");
 commander.option(
     '--context [path]', ` The base directory (absolute path!) for resolving the 'entry'`
 + ` option. If 'output.pathinfo' is set, the included pathinfo is shortened to this directory`,
-    undefined,
     'The current directory'
 );
 

--- a/src/swc/file.ts
+++ b/src/swc/file.ts
@@ -9,7 +9,6 @@ import sourceMap, { SourceMapGenerator } from "source-map";
 import { CliOptions } from "./options";
 import * as util from "./util";
 
-// @ts-ignore
 export default async function ({
   cliOptions,
   swcOptions
@@ -52,7 +51,7 @@ export default async function ({
               column: mapping.generatedColumn
             },
             source: mapping.source,
-            // @ts-ignore
+            // @ts-expect-error
             original:
               mapping.source == null
                 ? null
@@ -168,21 +167,21 @@ export default async function ({
 
     const results = await Promise.all(
       _filenames.map(async function (filename) {
-        let sourceFilename = filename;
+        let sourceFileName = filename;
         if (cliOptions.outFile) {
-          sourceFilename = path.relative(
+          sourceFileName = path.relative(
             path.dirname(cliOptions.outFile),
-            sourceFilename
+            sourceFileName
           );
         }
-        sourceFilename = slash(sourceFilename);
+        sourceFileName = slash(sourceFileName);
 
         try {
           return await util.compile(
             filename,
             defaults(
               {
-                sourceFileName: sourceFilename,
+                sourceFileName,
                 // Since we're compiling everything to be merged together,
                 // "inline" applies to the final output file, but to the individual
                 // files being concatenated.

--- a/src/swc/file.ts
+++ b/src/swc/file.ts
@@ -1,10 +1,9 @@
 import swc from "@swc/core";
-import convertSourceMap from "convert-source-map";
-import fs from "fs";
+import convertSourceMap from 'convert-source-map';
 import defaults from "lodash/defaults";
 import path from "path";
 import slash from "slash";
-import sourceMap, { SourceMapGenerator } from "source-map";
+import { SourceMapConsumer, SourceMapGenerator } from "source-map";
 
 import { CliOptions } from "./options";
 import * as util from "./util";
@@ -16,232 +15,196 @@ export default async function ({
   cliOptions: CliOptions;
   swcOptions: swc.Options;
 }) {
-  async function buildResult(
-    fileResults: (swc.Output | null)[]
-  ): Promise<{
-    code: string;
-    map: SourceMapGenerator;
-  }> {
-    const map = new sourceMap.SourceMapGenerator({
-      file:
-        cliOptions.sourceMapTarget ||
-        path.basename(cliOptions.outFile || "") ||
-        "stdout",
+  async function concatResults(
+    file: string,
+    ...results: swc.Output[]
+  ): Promise<swc.Output> {
+    const map = new SourceMapGenerator({
+      file,
       sourceRoot: swcOptions.sourceRoot
     });
 
     let code = "";
     let offset = 0;
 
-    for (const result of fileResults) {
-      if (!result) continue;
-
+    for (const result of results) {
       code += result.code + "\n";
 
       if (result.map) {
-        const consumer = await new sourceMap.SourceMapConsumer(result.map);
-        const sources = new Set();
+        const consumer = await new SourceMapConsumer(result.map);
+        const sources = new Set<string>();
 
-        consumer.eachMapping(function (mapping: any) {
-          if (mapping.source != null) sources.add(mapping.source);
-
+        consumer.eachMapping(mapping => {
+          sources.add(mapping.source);
           map.addMapping({
             generated: {
               line: mapping.generatedLine + offset,
               column: mapping.generatedColumn
             },
-            source: mapping.source,
-            // @ts-expect-error
-            original:
-              mapping.source == null
-                ? null
-                : {
-                  line: mapping.originalLine,
-                  column: mapping.originalColumn
-                }
+            original: {
+              line: mapping.originalLine,
+              column: mapping.originalColumn
+            },
+            source: mapping.source
           });
         });
 
         sources.forEach(source => {
-          const content = consumer.sourceContentFor(source as any, true);
+          const content = consumer.sourceContentFor(source, true);
           if (content !== null) {
-            map.setSourceContent(source as any, content);
+            map.setSourceContent(source, content);
           }
         });
-
-        offset = code.split("\n").length - 1;
       }
-    }
-
-    // add the inline sourcemap comment if we've either explicitly asked for inline source
-    // maps, or we've requested them without any output file
-    if (
-      swcOptions.sourceMaps === "inline" ||
-      (!cliOptions.outFile && swcOptions.sourceMaps)
-    ) {
-      code += "\n" + convertSourceMap.fromObject(map).toComment();
+      offset = code.split("\n").length - 1;
     }
 
     return {
-      map: map,
-      code: code
+      code,
+      map: JSON.stringify(map)
     };
   }
 
-  async function output(fileResults: (swc.Output | null)[]): Promise<void> {
-    const result = await buildResult(fileResults);
+  async function output(results: Iterable<swc.Output>) {
+    const file = cliOptions.sourceMapTarget || path.basename(cliOptions.outFile || "stdout");
+
+    const result = await concatResults(file, ...results);
 
     if (cliOptions.outFile) {
-      // we've requested for a sourcemap to be written to disk
-      if (swcOptions.sourceMaps && swcOptions.sourceMaps !== "inline") {
-        const mapLoc = cliOptions.outFile + ".map";
-        result.code = util.addSourceMappingUrl(result.code, mapLoc);
-        fs.writeFileSync(mapLoc, JSON.stringify(result.map));
-      }
-
-      fs.writeFileSync(cliOptions.outFile, result.code);
+      util.outputFile(result, cliOptions.outFile, swcOptions.sourceMaps);
     } else {
       process.stdout.write(result.code + "\n");
+      if (result.map && swcOptions.sourceMaps) {
+        process.stdout.write(convertSourceMap.fromJSON(result.map).toComment());
+      }
     }
   }
 
-  function readStdin(): Promise<string> {
-    return new Promise((resolve, reject) => {
-      let code = "";
-
-      process.stdin.setEncoding("utf8");
-
-      process.stdin.on("readable", function () {
-        const chunk = process.stdin.read();
-        if (chunk !== null) code += chunk;
-      });
-
-      process.stdin.on("end", function () {
-        resolve(code);
-      });
-      process.stdin.on("error", reject);
-    });
-  }
-
-  async function stdin() {
-    const code = await readStdin();
-
-    const res = await util.transform(
-      cliOptions.filename,
-      code,
+  async function handle(filename: string) {
+    const sourceFileName = slash(
+      cliOptions.outFile
+        ? path.relative(path.dirname(cliOptions.outFile), filename)
+        : filename
+    );
+    return await util.compile(
+      filename,
       defaults(
         {
-          sourceFileName: "stdin"
+          sourceFileName,
+          // Since we're compiling everything to be merged together,
+          // "inline" applies to the final output file, but not to the individual
+          // files being concatenated.
+          sourceMaps: Boolean(swcOptions.sourceMaps)
         },
         swcOptions
       ),
+      cliOptions.sync
+    );
+  }
+
+  function getProgram(previousResults: Map<string, swc.Output | Error> = new Map()) {
+    const results: typeof previousResults = new Map();
+    for (const filename of util.globSources(cliOptions.filenames, cliOptions.includeDotfiles)) {
+      if (util.isCompilableExtension(filename, cliOptions.extensions)) {
+        results.set(filename, previousResults.get(filename)!);
+      }
+    }
+    return results;
+  }
+
+  async function files() {
+    let results = getProgram();
+    for (const filename of results.keys()) {
+      try {
+        const result = await handle(filename);
+        if (result) {
+          results.set(filename, result);
+        } else {
+          results.delete(filename);
+        }
+      } catch (err) {
+        console.error(err.message);
+        results.set(filename, err);
+      }
+    }
+
+    if (cliOptions.watch) {
+      const watcher = util.watchSources(cliOptions.filenames, cliOptions.includeDotfiles);
+      watcher.on('ready', () => {
+        Promise.resolve()
+          .then(async () => {
+            util.assertCompilationResult(results, cliOptions.quiet);
+            await output(results.values());
+            if (!cliOptions.quiet) {
+              console.info('Watching for file changes.')
+            }
+          })
+          .catch((err) => {
+            console.error(err.message);
+          });
+      });
+      watcher.on("add", (filename) => {
+        if (util.isCompilableExtension(filename, cliOptions.extensions)) {
+          // ensure consistent insertion order when files are added
+          results = getProgram(results);
+        }
+      });
+      watcher.on("unlink", (filename) => {
+        results.delete(filename);
+      });
+      for (const type of ["add", "change"]) {
+        watcher.on(type, (filename) => {
+          if (!util.isCompilableExtension(filename, cliOptions.extensions)) {
+            return;
+          }
+    
+          const start = process.hrtime();
+  
+          handle(filename)
+            .then(async (result) => {
+              if (!result) {
+                results.delete(filename);
+                return;
+              }
+              results.set(filename, result);
+              util.assertCompilationResult(results, true);
+              await output(results.values());
+              if (cliOptions.logWatchCompilation) {
+                const [seconds, nanoseconds] = process.hrtime(start);
+                const ms = seconds * 1000 + (nanoseconds * 1e-6);
+                const name = path.basename(cliOptions.outFile);
+                console.log(`Compiled ${name} in ${ms.toFixed(2)}ms`);
+              }
+            })
+            .catch((err) => {
+              console.error(err.message);
+            });
+        });
+      }
+    } else {
+      util.assertCompilationResult(results, cliOptions.quiet);
+      await output(results.values());
+    }
+  }
+
+  async function stdin() {
+    let code = "";
+    process.stdin.setEncoding("utf8");
+    for await (const chunk of process.stdin) {
+      code += chunk;
+    }
+    const res = await util.transform(
+      cliOptions.filename,
+      code,
+      defaults({ sourceFileName: "stdin" }, swcOptions),
       cliOptions.sync
     );
 
     output([res]);
   }
 
-  async function walk(filenames: string[]) {
-    const _filenames: string[] = [];
-
-    filenames.forEach(function (filename) {
-      if (!fs.existsSync(filename)) return;
-
-      const stat = fs.statSync(filename);
-      if (stat.isDirectory()) {
-        const dirname = filename;
-
-        util
-          .readdirForCompilable(
-            filename,
-            cliOptions.includeDotfiles,
-            cliOptions.extensions
-          )
-          .forEach(function (filename: string) {
-            _filenames.push(path.join(dirname, filename));
-          });
-      } else {
-        _filenames.push(filename);
-      }
-    });
-
-    const results = await Promise.all(
-      _filenames.map(async function (filename) {
-        let sourceFileName = filename;
-        if (cliOptions.outFile) {
-          sourceFileName = path.relative(
-            path.dirname(cliOptions.outFile),
-            sourceFileName
-          );
-        }
-        sourceFileName = slash(sourceFileName);
-
-        try {
-          return await util.compile(
-            filename,
-            defaults(
-              {
-                sourceFileName,
-                // Since we're compiling everything to be merged together,
-                // "inline" applies to the final output file, but to the individual
-                // files being concatenated.
-                sourceMaps:
-                  swcOptions.sourceMaps === "inline"
-                    ? true
-                    : swcOptions.sourceMaps
-              },
-              swcOptions
-            ),
-            cliOptions.sync
-          );
-        } catch (err) {
-          if (!cliOptions.watch) {
-            throw err;
-          }
-
-          console.error(err);
-          return null;
-        }
-      })
-    );
-
-    output(results);
-  }
-
-  async function files(filenames: string[]) {
-    await walk(filenames);
-
-    if (cliOptions.watch) {
-      const chokidar = util.requireChokidar();
-      chokidar
-        .watch(filenames, {
-          persistent: true,
-          ignoreInitial: true,
-          awaitWriteFinish: {
-            stabilityThreshold: 50,
-            pollInterval: 10
-          }
-        })
-        .on("all", function (type: string, filename: string) {
-          if (!util.isCompilableExtension(filename, cliOptions.extensions)) {
-            return;
-          }
-
-          if (type === "add" || type === "change") {
-            if (cliOptions.verbose) {
-              console.log(type + " " + filename);
-            }
-
-            walk(filenames).catch(err => {
-              console.error(err);
-            });
-          }
-        });
-    }
-  }
-
   if (cliOptions.filenames.length) {
-    await files(cliOptions.filenames);
+    await files();
   } else {
     await stdin();
   }

--- a/src/swc/index.ts
+++ b/src/swc/index.ts
@@ -4,6 +4,12 @@ import parseArgs from "./options";
 
 const opts = parseArgs(process.argv);
 const fn = opts.cliOptions.outDir ? dirCommand : fileCommand;
+
+process.on("uncaughtException", function(err) {
+  console.error(err);
+  process.exit(1);
+});
+
 fn(opts).catch((err: Error) => {
   console.error(err);
   process.exit(1);

--- a/src/swc/options.ts
+++ b/src/swc/options.ts
@@ -1,4 +1,4 @@
-import { Options, version as swcCoreVersion } from "@swc/core";
+import { DEFAULT_EXTENSIONS, Options, version as swcCoreVersion } from "@swc/core";
 import commander from "commander";
 import { set } from "lodash";
 
@@ -134,10 +134,7 @@ export interface CliOptions {
   readonly filename: string;
   readonly filenames: string[];
   readonly extensions: string[];
-  readonly keepFileExtension: boolean;
-  readonly verbose: boolean;
   readonly watch: boolean;
-  readonly relative: boolean;
   readonly copyFiles: boolean;
   readonly includeDotfiles: boolean;
   readonly deleteDirOnStart: boolean;
@@ -226,11 +223,8 @@ export default function parserArgs(args: string[]) {
     filenames,
     sync: !!opts.sync,
     sourceMapTarget: opts.sourceMapTarget,
-    extensions: opts.extensions,
-    keepFileExtension: opts.keepFileExtension,
-    verbose: !!opts.verbose,
+    extensions: opts.extensions || DEFAULT_EXTENSIONS,
     watch: !!opts.watch,
-    relative: !!opts.relative,
     copyFiles: !!opts.copyFiles,
     includeDotfiles: !!opts.includeDotfiles,
     deleteDirOnStart: !!opts.deleteDirOnStart,

--- a/src/swc/util.ts
+++ b/src/swc/util.ts
@@ -1,43 +1,52 @@
 import * as swc from "@swc/core";
 import fs from "fs";
-import readdirRecursive from "fs-readdir-recursive";
-import includes from "lodash/includes";
+import glob from "glob";
+import uniq from "lodash/uniq";
 import path from "path";
+import slash from "slash";
 
 export function chmod(src: fs.PathLike, dest: fs.PathLike) {
   fs.chmodSync(dest, fs.statSync(src).mode);
 }
 
-type ReaddirFilter = (filename: string) => boolean;
-
-export function readdir(
-  dirname: fs.PathLike,
-  includeDotfiles: boolean,
-  filter?: ReaddirFilter
-) {
-  return readdirRecursive(
-    dirname.toString(),
-    // @ts-ignore
-    (filename: string, _index, currentDirectory: string) => {
-      const stat = fs.statSync(path.join(currentDirectory, filename));
-
-      if (stat.isDirectory()) return true;
-
-      return (
-        (includeDotfiles || filename[0] !== ".") &&
-        (!filter || filter(filename))
-      );
-    }
+export function globSources(
+  sources: string[],
+  includeDotfiles = false
+): string[] {
+  return uniq(
+    sources.flatMap(filename => {
+      if (!includeDotfiles && path.basename(filename).startsWith(".")) {
+        return [];
+      }
+      let stats: fs.Stats;
+      try {
+        stats = fs.statSync(filename);
+      } catch (err) {
+        return [];
+      }
+      return stats.isDirectory()
+        ? glob.sync(path.join(filename, "**"), {
+            dot: includeDotfiles,
+            nodir: true
+          })
+        : [filename];
+    })
   );
 }
 
-export function readdirForCompilable(
-  dirname: string,
-  includeDotfiles: boolean,
-  altExts?: string[]
-): string[] {
-  return readdir(dirname, includeDotfiles, function(filename) {
-    return isCompilableExtension(filename, altExts);
+export function watchSources(
+  sources: string[],
+  includeDotfiles = false
+) {
+  return requireChokidar().watch(sources, {
+    ignored: includeDotfiles
+      ? undefined
+      : (filename: string) => path.basename(filename).startsWith("."),
+    ignoreInitial: true,
+    awaitWriteFinish: {
+      stabilityThreshold: 50,
+      pollInterval: 10
+    }
   });
 }
 
@@ -46,14 +55,10 @@ export function readdirForCompilable(
  */
 export function isCompilableExtension(
   filename: string,
-  altExts: readonly string[] = swc.DEFAULT_EXTENSIONS
+  altExts: string[]
 ): boolean {
   const ext = path.extname(filename);
-  return includes(altExts, ext);
-}
-
-export function addSourceMappingUrl(code: string, loc: string) {
-  return code + "\n//# sourceMappingURL=" + path.basename(loc);
+  return altExts.includes(ext);
 }
 
 export async function transform(
@@ -78,40 +83,72 @@ export async function compile(
   filename: string,
   opts: swc.Options,
   sync: boolean
-): Promise<swc.Output> {
+): Promise<swc.Output | undefined> {
   opts = {
     ...opts
   };
 
-  if (sync) {
-    return swc.transformFileSync(filename, opts);
-  }
-
-  return swc.transformFile(filename, opts);
-}
-
-export function deleteDir(path: fs.PathLike) {
-  if (fs.existsSync(path)) {
-    fs.readdirSync(path).forEach(function(file) {
-      const curPath = path + "/" + file;
-      if (fs.lstatSync(curPath).isDirectory()) {
-        // recurse
-        deleteDir(curPath);
-      } else {
-        // delete file
-        fs.unlinkSync(curPath);
-      }
-    });
-    fs.rmdirSync(path);
+  try {
+    return sync
+      ? swc.transformFileSync(filename, opts)
+      : await swc.transformFile(filename, opts);
+  } catch (err) {
+    if (!err.message.includes("ignored by .swcrc")) {
+      throw err;
+    }
   }
 }
 
-process.on("uncaughtException", function(err) {
-  console.error(err);
-  process.exit(1);
-});
+export function outputFile(
+  output: swc.Output,
+  filename: string,
+  sourceMaps: swc.Options['sourceMaps']
+) {
+  const destDir = path.dirname(filename);
+  fs.mkdirSync(destDir, { recursive: true });
 
-export function requireChokidar() {
+  let code = output.code;
+  if (output.map && sourceMaps && sourceMaps !== "inline") {
+    // we've requested for a sourcemap to be written to disk
+    const mapLoc = filename + ".map";
+    code += "\n//# sourceMappingURL=" + slash(path.relative(filename, mapLoc));
+    fs.writeFileSync(mapLoc, output.map);
+  }
+
+  fs.writeFileSync(filename, code);
+}
+
+export function assertCompilationResult<T>(
+  result: Map<string, Error | T>,
+  quiet = false
+): asserts result is Map<string, T> {
+  let compiled = 0;
+  let copied = 0;
+  let failed = 0;
+  for (const value of result.values()) {
+    if (value instanceof Error) {
+      failed++;
+    } else if (value as unknown === 'copied') {
+      copied++;
+    } else if (value) {
+      compiled++;
+    }
+  }
+  if (!quiet && compiled + copied > 0) {
+    const copyResult = copied === 0 ? " " : ` (copied ${copied}) `;
+    console.info(
+      `Successfully compiled ${compiled} ${compiled !== 1 ? "files" : "file"}${copyResult}with swc.`
+    );
+  }
+
+  if (failed > 0) {
+    throw new Error(
+      `Failed to compile ${failed} ${failed !== 1 ? "files" : "file"} with swc.`
+    );
+  }
+}
+
+export function requireChokidar(): (typeof import("chokidar")) {
   try {
     return require("chokidar");
   } catch (err) {
@@ -121,11 +158,4 @@ export function requireChokidar() {
     );
     throw err;
   }
-}
-
-export function adjustRelative(relative: string, keepFileExtension: boolean) {
-  if (keepFileExtension) {
-    return relative;
-  }
-  return relative.replace(/\.(\w*?)$/, "") + ".js";
 }

--- a/src/swc/util.ts
+++ b/src/swc/util.ts
@@ -16,8 +16,7 @@ export function readdir(
   filter?: ReaddirFilter
 ) {
   return readdirRecursive(
-    // @ts-ignore
-    dirname,
+    dirname.toString(),
     // @ts-ignore
     (filename: string, _index, currentDirectory: string) => {
       const stat = fs.statSync(path.join(currentDirectory, filename));
@@ -35,7 +34,7 @@ export function readdir(
 export function readdirForCompilable(
   dirname: string,
   includeDotfiles: boolean,
-  altExts?: Array<string>
+  altExts?: string[]
 ): string[] {
   return readdir(dirname, includeDotfiles, function(filename) {
     return isCompilableExtension(filename, altExts);
@@ -47,11 +46,10 @@ export function readdirForCompilable(
  */
 export function isCompilableExtension(
   filename: string,
-  altExts?: Array<string>
+  altExts: readonly string[] = swc.DEFAULT_EXTENSIONS
 ): boolean {
-  const exts = altExts || [".js", ".jsx", ".es6", ".es", ".mjs", ".ts", ".tsx"];
   const ext = path.extname(filename);
-  return includes(exts, ext);
+  return includes(altExts, ext);
 }
 
 export function addSourceMappingUrl(code: string, loc: string) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     /* Basic Options */
-    "target": "es2015" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */,
+    "target": "es2019" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */,
     "module": "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */,
     // "lib": [],                             /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */


### PR DESCRIPTION
This consolidates most of the logic within the dir and file modes of the CLI, around 100 lines were able to be removed. Due to Node 10's EOL in April and there being places where `flatMap` and `fs.rmdir(..., { recursive: true })` are helpful, I've bumped the minimum Node version to v12. Let me know if it's an issue to be dropping Node 10 support a bit prematurely.

This closes both #11 and #17. This also provides a simple fix to swc-project/swc#1255 (I've documented the root cause as a comment referencing swc-project/swc#1388).

I noticed 3 options on the `CliOptions` interface that had no corresponding commander option that I removed:
* verbose
* keepFileExtension
* relative

Aside from that, I thought it was strange behavior to have `--quiet` prevent errors from writing to stderr. It already had no influence over the unhandled promise rejection handler, so now errors will log in a few more places regardless of the presence of `--quiet`. Additionally, I made it so that file deletions in directory watch mode will delete output files when they exist. Aside from these, no new behavior was added.