### PR TITLE
Include bin directory in package.json files

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "spack": "./bin/spack.js"
   },
   "files": [
+    "bin",
     "lib"
   ]
 }


### PR DESCRIPTION
After #18 it looks like the bin directory is not included in the npm package.

The newest release also looks a little weird; it includes both examples and other files that I don't get locally when running `yarn pack`.

This MR adds the bin directory to the npm package.