### PR TITLE
feat(): async getSources

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,8 @@
 {
   "editor.formatOnSave": true,
-  "typescriptHero.imports.organizeOnSave": false
+  "typescriptHero.imports.organizeOnSave": false,
+  "cSpell.words": [
+    "Dotfiles",
+    "nodir"
+  ]
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,6 @@
+
+module.exports = {
+  transform: {
+    '^.+\\.(t|j)sx?$': ['@swc/jest'],
+  },
+};

--- a/package.json
+++ b/package.json
@@ -41,8 +41,10 @@
   },
   "devDependencies": {
     "@swc/core": "^1.2.4",
+    "@swc/jest": "^0.1.2",
     "@types/convert-source-map": "^1.5.1",
     "@types/glob": "^7.1.2",
+    "@types/jest": "^26.0.23",
     "@types/lodash": "^4.14.155",
     "@types/node": "^12.19.16",
     "chokidar": "^3.5.1",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "@swc/core": "^1.2.4",
     "@swc/jest": "^0.1.2",
     "@types/convert-source-map": "^1.5.1",
-    "@types/glob": "^7.1.2",
     "@types/jest": "^26.0.23",
     "@types/lodash": "^4.14.155",
     "@types/node": "^12.19.16",
@@ -54,7 +53,7 @@
   "dependencies": {
     "commander": "^7.1.0",
     "convert-source-map": "^1.6.0",
-    "glob": "^7.1.3",
+    "fast-glob": "^3.2.5",
     "lodash": "^4.17.11",
     "slash": "3.0.0",
     "source-map": "^0.7.3"

--- a/src/.swcrc
+++ b/src/.swcrc
@@ -1,5 +1,6 @@
 {
     "jsc": {
+        "target": "es2019",
         "parser": {
             "syntax": "typescript"
         }

--- a/src/swc/__mocks__/fs.ts
+++ b/src/swc/__mocks__/fs.ts
@@ -1,0 +1,37 @@
+import fs from 'fs';
+import type { Stats } from "fs";
+
+
+export interface MockHelpers {
+  resetMockStats: () => void;
+  setMockStats: (stats: Record<string, Stats | Error>) => void;
+}
+
+const fsMock = jest.createMockFromModule<typeof fs & MockHelpers>('fs');
+
+let mockStats: Record<string, Stats | Error> = {}
+
+function setMockStats(stats: Record<string, Stats | Error>) {
+  Object.entries(stats).forEach(([path, stats]) => {
+    mockStats[path] = stats;
+  });
+}
+function resetMockStats() {
+  mockStats = {};
+}
+
+export function stat(path: string, cb: (err?: Error, stats?: Stats) => void) {
+  const result = mockStats[path];
+  if (result instanceof Error) {
+    cb(result, undefined);
+  } else {
+    cb(undefined, result);
+  }
+}
+
+fsMock.setMockStats = setMockStats;
+fsMock.resetMockStats = resetMockStats;
+
+fsMock.stat = stat as typeof fs.stat;
+
+export default fsMock;

--- a/src/swc/__tests__/utils.test.ts
+++ b/src/swc/__tests__/utils.test.ts
@@ -3,7 +3,7 @@ import fs from 'fs'
 import glob from "fast-glob";
 
 jest.mock('fs');
-jest.mock('glob');
+jest.mock('fast-glob');
 
 describe('globSources', () => {
   beforeEach(() => {

--- a/src/swc/__tests__/utils.test.ts
+++ b/src/swc/__tests__/utils.test.ts
@@ -1,6 +1,6 @@
 import { globSources } from "../util";
 import fs from 'fs'
-import glob from "glob";
+import glob from "fast-glob";
 
 jest.mock('fs');
 jest.mock('glob');
@@ -44,9 +44,7 @@ describe('globSources', () => {
     (fs as any).setMockStats({ "directory": { isDirectory: () => true } });
     (fs as any).setMockStats({ "file": { isDirectory: () => false } });
 
-    (glob as unknown as jest.Mock).mockImplementation((pattern: string, config: object, cb: Function) => {
-      cb(undefined, ["fileDir1", "fileDir2"])
-    });
+    (glob as unknown as jest.Mock).mockResolvedValue(["fileDir1", "fileDir2"]);
     const files = await globSources(["file", "directory"], true);
 
     expect([...files]).toEqual([
@@ -60,9 +58,7 @@ describe('globSources', () => {
     (fs as any).setMockStats({ "directory": { isDirectory: () => true } });
     (fs as any).setMockStats({ "file": { isDirectory: () => false } });
 
-    (glob as unknown as jest.Mock).mockImplementation((pattern: string, config: object, cb: Function) => {
-      cb(new Error("Failed"))
-    });
+    (glob as unknown as jest.Mock).mockRejectedValue(new Error("Failed"));
     const files = await globSources(["file", "directory"], true);
 
     expect([...files]).toEqual([

--- a/src/swc/__tests__/utils.test.ts
+++ b/src/swc/__tests__/utils.test.ts
@@ -1,0 +1,72 @@
+import { globSources } from "../util";
+import fs from 'fs'
+import glob from "glob";
+
+jest.mock('fs');
+jest.mock('glob');
+
+describe('globSources', () => {
+  beforeEach(() => {
+    (fs as any).resetMockStats();
+  });
+
+  it("exclude dotfiles sources when includeDotfiles=false", async () => {
+    const files = await globSources([".dotfile"], false);
+
+    expect([...files]).toEqual([]);
+  });
+
+  it("include dotfiles sources when includeDotfiles=true", async () => {
+    (fs as any).setMockStats({ ".dotfile": { isDirectory: () => false } })
+    const files = await globSources([".dotfile"], true);
+
+    expect([...files]).toEqual([".dotfile"]);
+  });
+
+
+  it("include multiple file sources", async () => {
+    (fs as any).setMockStats({ ".dotfile": { isDirectory: () => false } });
+    (fs as any).setMockStats({ "file": { isDirectory: () => false } });
+    const files = await globSources([".dotfile", "file"], true);
+
+    expect([...files]).toEqual(['.dotfile', "file"]);
+  });
+
+  it("exclude files that errors on stats", async () => {
+    (fs as any).setMockStats({ ".dotfile": { isDirectory: () => false } });
+    (fs as any).setMockStats({ "file": new Error('Failed stat') });
+    const files = await globSources([".dotfile", "file"], true);
+
+    expect([...files]).toEqual(['.dotfile']);
+  });
+
+  it("includes all files from directory", async () => {
+    (fs as any).setMockStats({ "directory": { isDirectory: () => true } });
+    (fs as any).setMockStats({ "file": { isDirectory: () => false } });
+
+    (glob as unknown as jest.Mock).mockImplementation((pattern: string, config: object, cb: Function) => {
+      cb(undefined, ["fileDir1", "fileDir2"])
+    });
+    const files = await globSources(["file", "directory"], true);
+
+    expect([...files]).toEqual([
+      "file",
+      "fileDir1",
+      "fileDir2"
+    ]);
+  });
+
+  it("exclude files from directory that fail to glob", async () => {
+    (fs as any).setMockStats({ "directory": { isDirectory: () => true } });
+    (fs as any).setMockStats({ "file": { isDirectory: () => false } });
+
+    (glob as unknown as jest.Mock).mockImplementation((pattern: string, config: object, cb: Function) => {
+      cb(new Error("Failed"))
+    });
+    const files = await globSources(["file", "directory"], true);
+
+    expect([...files]).toEqual([
+      "file",
+    ]);
+  });
+});

--- a/src/swc/dir.ts
+++ b/src/swc/dir.ts
@@ -47,7 +47,7 @@ export default async function ({
         defaults({ sourceFileName }, swcOptions),
         cliOptions.sync
       );
-  
+
       if (result) {
         util.outputFile(result, dest, swcOptions.sourceMaps);
         util.chmod(filename, dest);
@@ -68,7 +68,7 @@ export default async function ({
   fs.mkdirSync(cliOptions.outDir, { recursive: true });
 
   const results = new Map<string, Error | boolean | 'copied'>();
-  for (const filename of util.globSources(cliOptions.filenames, cliOptions.includeDotfiles)) {
+  for (const filename of await util.globSources(cliOptions.filenames, cliOptions.includeDotfiles)) {
     try {
       const result = await handle(filename);
       if (result !== undefined) {

--- a/src/swc/file.ts
+++ b/src/swc/file.ts
@@ -102,9 +102,10 @@ export default async function ({
     );
   }
 
-  function getProgram(previousResults: Map<string, swc.Output | Error> = new Map()) {
+  async function getProgram(previousResults: Map<string, swc.Output | Error> = new Map()) {
     const results: typeof previousResults = new Map();
-    for (const filename of util.globSources(cliOptions.filenames, cliOptions.includeDotfiles)) {
+
+    for (const filename of await util.globSources(cliOptions.filenames, cliOptions.includeDotfiles)) {
       if (util.isCompilableExtension(filename, cliOptions.extensions)) {
         results.set(filename, previousResults.get(filename)!);
       }
@@ -113,7 +114,7 @@ export default async function ({
   }
 
   async function files() {
-    let results = getProgram();
+    let results = await getProgram();
     for (const filename of results.keys()) {
       try {
         const result = await handle(filename);
@@ -143,10 +144,10 @@ export default async function ({
             console.error(err.message);
           });
       });
-      watcher.on("add", (filename) => {
+      watcher.on("add", async (filename) => {
         if (util.isCompilableExtension(filename, cliOptions.extensions)) {
           // ensure consistent insertion order when files are added
-          results = getProgram(results);
+          results = await getProgram(results);
         }
       });
       watcher.on("unlink", (filename) => {

--- a/src/swc/index.ts
+++ b/src/swc/index.ts
@@ -5,7 +5,7 @@ import parseArgs from "./options";
 const opts = parseArgs(process.argv);
 const fn = opts.cliOptions.outDir ? dirCommand : fileCommand;
 
-process.on("uncaughtException", function(err) {
+process.on("uncaughtException", function (err) {
   console.error(err);
   process.exit(1);
 });

--- a/src/swc/util.ts
+++ b/src/swc/util.ts
@@ -1,38 +1,54 @@
 import * as swc from "@swc/core";
 import convertSourceMap from 'convert-source-map';
-import fs from "fs";
+import { stat, chmodSync, statSync, mkdirSync, writeFileSync } from "fs";
+import type { PathLike } from 'fs';
 import glob from "glob";
-import uniq from "lodash/uniq";
 import path from "path";
 import slash from "slash";
 
-export function chmod(src: fs.PathLike, dest: fs.PathLike) {
-  fs.chmodSync(dest, fs.statSync(src).mode);
+export function chmod(src: PathLike, dest: PathLike) {
+  chmodSync(dest, statSync(src).mode);
 }
 
-export function globSources(
+/**
+ * Find all input files based on source globs
+ */
+export async function globSources(
   sources: string[],
   includeDotfiles = false
-): string[] {
-  return uniq(
-    sources.flatMap(filename => {
-      if (!includeDotfiles && path.basename(filename).startsWith(".")) {
-        return [];
-      }
-      let stats: fs.Stats;
-      try {
-        stats = fs.statSync(filename);
-      } catch (err) {
-        return [];
-      }
-      return stats.isDirectory()
-        ? glob.sync(path.join(filename, "**"), {
-            dot: includeDotfiles,
-            nodir: true
-          })
-        : [filename];
-    })
-  );
+): Promise<Set<string>> {
+  const globConfig = {
+    dot: includeDotfiles,
+    nodir: true,
+    stat: false,
+  };
+
+  const files = await Promise.all(
+    sources
+      .filter(source => includeDotfiles || !path.basename(source).startsWith("."))
+      .map((source) => {
+        return new Promise<string[]>(resolve => {
+          stat(source, (err, stat) => {
+            if (err) {
+              resolve([]);
+              return;
+            }
+            if (!stat.isDirectory()) {
+              resolve([source])
+            } else {
+              glob(path.join(source, "**"), globConfig, (err, matches) => {
+                if (err) {
+                  resolve([]);
+                  return;
+                }
+                resolve(matches);
+              });
+            }
+          });
+        });
+      })
+  )
+  return new Set<string>(files.flat());
 }
 
 export function watchSources(
@@ -120,7 +136,7 @@ export function outputFile(
   sourceMaps: swc.Options['sourceMaps']
 ) {
   const destDir = path.dirname(filename);
-  fs.mkdirSync(destDir, { recursive: true });
+  mkdirSync(destDir, { recursive: true });
 
   let code = output.code;
   if (output.map && sourceMaps && sourceMaps !== "inline") {
@@ -128,10 +144,10 @@ export function outputFile(
     const fileDirName = path.dirname(filename);
     const mapLoc = filename + ".map";
     code += "\n//# sourceMappingURL=" + slash(path.relative(fileDirName, mapLoc));
-    fs.writeFileSync(mapLoc, output.map);
+    writeFileSync(mapLoc, output.map);
   }
 
-  fs.writeFileSync(filename, code);
+  writeFileSync(filename, code);
 }
 
 export function assertCompilationResult<T>(
@@ -170,7 +186,7 @@ export function requireChokidar(): (typeof import("chokidar")) {
   } catch (err) {
     console.error(
       "The optional dependency chokidar failed to install and is required for " +
-        "--watch. Chokidar is likely not supported on your platform."
+      "--watch. Chokidar is likely not supported on your platform."
     );
     throw err;
   }

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -5,5 +5,11 @@
     "rootDir": "./src",
     "noEmit": false,
   },
-  "include": ["src"]
+  "include": [
+    "src"
+  ],
+  "exclude": [
+    "**/__tests__/**",
+    "**/__mocks__/**"
+  ]
 }


### PR DESCRIPTION
- refactored getSources util to use aync stat and glob
- changes signature from string[] to Set<string>
- Added test setup using existing jest and tests for getSources
- Update swcrc target to avoid installing regenerator runtime
- Updated tsconfig.build.json to exclude test files and mocks

I am thinking on working on this more and slowly refactor other function yo remove any *sync functions.
Additionally, it would be interesting to run swc compilation on multiple worker threads. (unless swc already can saturate all cores?)

Can you point me with large repo using swc ? I do not have good example to test/bench my chnages. 
 