### PR TITLE
Fix no directory output for Windows

### DIFF
--- a/src/swc/util.ts
+++ b/src/swc/util.ts
@@ -26,7 +26,7 @@ export function globSources(
         return [];
       }
       return stats.isDirectory()
-        ? glob.sync(path.join(filename, "**"), {
+        ? glob.sync(slash(path.join(filename, "**")), {
             dot: includeDotfiles,
             nodir: true
           })


### PR DESCRIPTION
Fixes #27.

The root of the issue is the `fast-glob` package that is unable to work with backslash `\` in paths. The same comes for `glob` package that is used in `0.1.43`.