### PR TITLE
Fix --config option to properly set values

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,15 @@
+const enableCoverage = process.env.JEST_COVERAGE === 'true'
 
-module.exports = {
-  roots: ["src"],
-  transform: {
-    '^.+\\.(t|j)sx?$': ['@swc/jest'],
-  },
-};
+module.exports = enableCoverage
+  ? {
+    // provides the most accurate coverage results
+    preset: 'ts-jest',
+    roots: ["src"],
+  }
+  : {
+    roots: ["src"],
+    // provides fastest test transforms
+    transform: {
+      '^.+\\.(t|j)sx?$': ['@swc/jest'],
+    },
+  };

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "build": "swc src -d lib",
     "build:watch": "swc src -d lib --watch",
     "test": "jest",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "test:coverage": "JEST_COVERAGE=true jest --coverage"
   },
   "repository": {
     "type": "git",
@@ -53,6 +54,7 @@
     "@types/node": "^12.19.16",
     "chokidar": "^3.5.1",
     "jest": "^27.0.3",
+    "ts-jest": "^27.0.4",
     "typescript": "~4.3.2"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@types/jest": "^26.0.23",
     "@types/node": "^12.19.16",
     "chokidar": "^3.5.1",
+    "deepmerge": "^4.2.2",
     "jest": "^27.0.3",
     "ts-jest": "^27.0.4",
     "typescript": "~4.3.2"

--- a/src/swc/__tests__/options.test.ts
+++ b/src/swc/__tests__/options.test.ts
@@ -1,0 +1,242 @@
+import type { Options } from "@swc/core";
+import deepmerge from 'deepmerge'
+
+import parserArgs, { CliOptions, initProgram } from "../options";
+
+interface ParserArgsReturn {
+  swcOptions: Options;
+  cliOptions: CliOptions;
+}
+
+const createDefaultResult = (): ParserArgsReturn => ({
+  "cliOptions": {
+    "copyFiles": false,
+    "deleteDirOnStart": false,
+    "extensions": [".js", ".jsx", ".es6", ".es", ".mjs", ".ts", ".tsx"],
+    // @ts-expect-error
+    "filename": undefined,
+    "filenames": ["src"],
+    "includeDotfiles": false,
+    // @ts-expect-error
+    "outDir": undefined,
+    // @ts-expect-error
+    "outFile": undefined,
+    "quiet": false,
+    "sourceMapTarget": undefined,
+    "sync": false,
+    "watch": false
+  },
+  "swcOptions": {
+    "configFile": undefined,
+    "jsc": { "parser": undefined, "transform": {} },
+    "sourceFileName": undefined,
+    "sourceMaps": undefined,
+    "sourceRoot": undefined
+  }
+})
+
+describe('parserArgs', () => {
+  let defaultResult: ParserArgsReturn
+
+  beforeEach(() => {
+    defaultResult = createDefaultResult()
+    initProgram()
+  })
+
+  it("minimal args returns default result", async () => {
+    const args = [
+      'node',
+      '/path/to/node_modules/swc-cli/bin/swc.js',
+      'src'
+    ]
+    const result = await parserArgs(args);
+    expect(result).toEqual(defaultResult);
+  });
+
+  describe('errors', () => {
+    let mockExit: jest.SpyInstance
+    let mockConsoleError: jest.SpyInstance
+
+    beforeAll(() => {
+      //@ts-expect-error
+      mockExit = jest.spyOn(process, 'exit').mockImplementation(() => { });
+      mockConsoleError = jest.spyOn(console, 'error').mockImplementation(() => { });
+    })
+
+    beforeEach(() => {
+      mockExit.mockClear()
+      mockConsoleError.mockClear()
+    })
+
+    afterAll(() => {
+      mockExit.mockRestore()
+      mockConsoleError.mockRestore()
+    })
+
+    it('exits without filenames', async () => {
+      const args = [
+        'node',
+        '/path/to/node_modules/swc-cli/bin/swc.js',
+      ]
+      await parserArgs(args);
+      expect(mockExit).toHaveBeenCalledWith(2);
+      expect(mockConsoleError).toHaveBeenCalledTimes(2);
+    })
+
+    it('--watch exits without --out-dir', async () => {
+      const args = [
+        'node',
+        '/path/to/node_modules/swc-cli/bin/swc.js',
+        'src',
+        '--watch',
+      ]
+      await parserArgs(args);
+      expect(mockExit).toHaveBeenCalledWith(2);
+      expect(mockConsoleError).toHaveBeenCalledTimes(2);
+    })
+
+    it('--watch exits without filenames', async () => {
+      const args = [
+        'node',
+        '/path/to/node_modules/swc-cli/bin/swc.js',
+        '--watch',
+        '--out-dir',
+        'esm'
+      ]
+      await parserArgs(args);
+      expect(mockExit).toHaveBeenCalledWith(2);
+      expect(mockConsoleError).toHaveBeenCalledTimes(3);
+    })
+
+    it('--out-dir exits with conflicting -out-file', async () => {
+      const args = [
+        'node',
+        '/path/to/node_modules/swc-cli/bin/swc.js',
+        'src',
+        '--out-file',
+        'esm/index.js',
+        '--out-dir',
+        'esm'
+      ]
+      await parserArgs(args);
+      expect(mockExit).toHaveBeenCalledWith(2);
+      expect(mockConsoleError).toHaveBeenCalledTimes(2);
+    })
+  })
+
+  describe('--source-maps', () => {
+    it("source maps is ambiguous", async () => {
+      const args = [
+        'node',
+        '/path/to/node_modules/swc-cli/bin/swc.js',
+        'src',
+        '--source-maps'
+      ]
+      const result = await parserArgs(args);
+      const expectedOptions = deepmerge(defaultResult, { swcOptions: { sourceMaps: true } })
+      expect(result).toEqual(expectedOptions);
+    });
+
+    it("source maps true", async () => {
+      const args = [
+        'node',
+        '/path/to/node_modules/swc-cli/bin/swc.js',
+        '--source-maps',
+        'true',
+        'src'
+      ]
+      const result = await parserArgs(args);
+      const expectedOptions = deepmerge(defaultResult, { swcOptions: { sourceMaps: true } })
+      expect(result).toEqual(expectedOptions);
+    });
+
+    it("source maps inline", async () => {
+      const args = [
+        'node',
+        '/path/to/node_modules/swc-cli/bin/swc.js',
+        '-s',
+        'inline',
+        'src'
+      ]
+      const result = await parserArgs(args);
+      const expectedOptions = deepmerge(defaultResult, { swcOptions: { sourceMaps: 'inline' } })
+      expect(result).toEqual(expectedOptions);
+    });
+  });
+
+  describe('--config', () => {
+    it("throws with no config", async () => {
+      const args = [
+        'node',
+        '/path/to/node_modules/swc-cli/bin/swc.js',
+        'src',
+        '-C',
+      ]
+      expect(() => parserArgs(args)).toThrow();
+    });
+
+    it("react development", async () => {
+      const args = [
+        'node',
+        '/path/to/node_modules/swc-cli/bin/swc.js',
+        '--config',
+        'jsc.transform.react.development=true',
+        'src'
+      ]
+      const result = await parserArgs(args);
+      const expectedOptions = deepmerge(defaultResult.swcOptions, {
+        jsc: { transform: { react: { development: true } } }
+      })
+      expect(result.swcOptions).toEqual(expectedOptions);
+    });
+
+    it("react development and commonjs (two config options)", async () => {
+      const args = [
+        'node',
+        '/path/to/node_modules/swc-cli/bin/swc.js',
+        '--config',
+        'jsc.transform.react.development=true',
+        '-C',
+        'module.type=commonjs',
+        'src'
+      ]
+      const result = await parserArgs(args);
+      const expectedOptions = deepmerge(defaultResult.swcOptions, {
+        jsc: { transform: { react: { development: true } } },
+        module: { type: 'commonjs' }
+      })
+      expect(result.swcOptions).toEqual(expectedOptions);
+    });
+
+    it("react development and commonjs (comma-separated)", async () => {
+      const args = [
+        'node',
+        '/path/to/node_modules/swc-cli/bin/swc.js',
+        '--config',
+        'jsc.transform.react.development=true,module.type=commonjs',
+        'src'
+      ]
+      const result = await parserArgs(args);
+      const expectedOptions = deepmerge(defaultResult.swcOptions, {
+        jsc: { transform: { react: { development: true } } },
+        module: { type: 'commonjs' }
+      })
+      expect(result.swcOptions).toEqual(expectedOptions);
+    });
+
+    it("no equals sign", async () => {
+      const args = [
+        'node',
+        '/path/to/node_modules/swc-cli/bin/swc.js',
+        '--config',
+        'no_equals',
+        'src'
+      ]
+      const result = await parserArgs(args);
+      const expectedOptions = deepmerge(defaultResult.swcOptions, {
+        no_equals: true
+      })
+      expect(result.swcOptions).toEqual(expectedOptions);
+    });
+  })
+})

--- a/src/swc/index.ts
+++ b/src/swc/index.ts
@@ -1,7 +1,8 @@
 import dirCommand from "./dir";
 import fileCommand from "./file";
-import parseArgs from "./options";
+import parseArgs, { initProgram } from "./options";
 
+initProgram()
 const opts = parseArgs(process.argv);
 const fn = opts.cliOptions.outDir ? dirCommand : fileCommand;
 

--- a/src/swc/options.ts
+++ b/src/swc/options.ts
@@ -154,14 +154,14 @@ function collect(value: string, previousValue?: string[]): string[] | undefined 
 }
 
 export interface CliOptions {
-  readonly outDir: string;
-  readonly outFile: string;
+  readonly outDir?: string;
+  readonly outFile?: string;
   /**
    * Invoke swc using transformSync. It's useful for debugging.
    */
   readonly sync: boolean;
-  readonly sourceMapTarget: string;
-  readonly filename: string;
+  readonly sourceMapTarget?: string;
+  readonly filename?: string;
   readonly filenames: string[];
   readonly extensions: string[];
   readonly watch: boolean;

--- a/src/swc/options.ts
+++ b/src/swc/options.ts
@@ -154,14 +154,14 @@ function collect(value: string, previousValue?: string[]): string[] | undefined 
 }
 
 export interface CliOptions {
-  readonly outDir?: string;
-  readonly outFile?: string;
+  readonly outDir: string;
+  readonly outFile: string;
   /**
    * Invoke swc using transformSync. It's useful for debugging.
    */
   readonly sync: boolean;
   readonly sourceMapTarget?: string;
-  readonly filename?: string;
+  readonly filename: string;
   readonly filenames: string[];
   readonly extensions: string[];
   readonly watch: boolean;
@@ -239,8 +239,20 @@ export default function parserArgs(args: string[]) {
         key = cfg.substring(0, i);
         value = unstringify(cfg.substring(i + 1));
       }
-      //@ts-expect-error
-      swcOptions[key] = value;
+      // https://github.com/swc-project/cli/issues/45
+      let options = swcOptions as { [key: string]: any }
+      const keyParts = key.split('.')
+      const lastIndex = keyParts.length - 1
+      for (const [index, keyPart] of keyParts.entries()) {
+        if (options[keyPart] === undefined && index !== lastIndex) {
+          options[keyPart] = {}
+        }
+        if (index === lastIndex) {
+          options[keyPart] = value
+        } else {
+          options = options[keyPart]
+        }
+      }
     }
   }
 

--- a/src/swc/options.ts
+++ b/src/swc/options.ts
@@ -4,124 +4,136 @@ import type { Options } from "@swc/core";
 
 const pkg = require("../../package.json");
 
-commander.option(
-  "-f, --filename [filename]",
-  "filename to use when reading from stdin - this will be used in source-maps, errors etc"
-);
+let program: commander.Command
 
-commander.option(
-  "--config-file [path]",
-  "Path to a .swcrc file to use"
-);
+export const initProgram = () => {
+  program = new commander.Command()
 
-commander.option(
-  "--env-name [name]",
-  "The name of the 'env' to use when loading configs and plugins. " +
-  "Defaults to the value of SWC_ENV, or else NODE_ENV, or else 'development'."
-);
+  /* istanbul ignore next */
+  if (process.env.NODE_ENV === 'test') {
+    program.exitOverride();
+  }
 
-commander.option(
-  "--no-swcrc",
-  "Whether or not to look up .swcrc files"
-);
 
-commander.option(
-  "--delete-dir-on-start",
-  "Whether or not delete output directory on start"
-);
+  program.option(
+    "-f, --filename [filename]",
+    "filename to use when reading from stdin - this will be used in source-maps, errors etc"
+  );
 
-commander.option(
-  "--ignore [list]",
-  "list of glob paths to **not** compile",
-  collect
-);
+  program.option(
+    "--config-file [path]",
+    "Path to a .swcrc file to use"
+  );
 
-commander.option(
-  "--only [list]",
-  "list of glob paths to **only** compile",
-  collect
-);
+  program.option(
+    "--env-name [name]",
+    "The name of the 'env' to use when loading configs and plugins. " +
+    "Defaults to the value of SWC_ENV, or else NODE_ENV, or else 'development'."
+  );
 
-commander.option(
-  "-w, --watch",
-  "Recompile files on changes"
-);
+  program.option(
+    "--no-swcrc",
+    "Whether or not to look up .swcrc files"
+  );
 
-commander.option(
-  "-q, --quiet",
-  "Suppress compilation output"
-);
+  program.option(
+    "--delete-dir-on-start",
+    "Whether or not delete output directory on start"
+  );
 
-commander.option(
-  "-s, --source-maps [true|false|inline|both]",
-  "generate source maps",
-  unstringify
-);
+  program.option(
+    "--ignore [list]",
+    "list of glob paths to **not** compile",
+    collect
+  );
 
-commander.option(
-  "--source-map-target [string]",
-  "set `file` on returned source map"
-);
+  program.option(
+    "--only [list]",
+    "list of glob paths to **only** compile",
+    collect
+  );
 
-commander.option(
-  "--source-file-name [string]",
-  "set `sources[0]` on returned source map"
-);
+  program.option(
+    "-w, --watch",
+    "Recompile files on changes"
+  );
 
-commander.option(
-  "--source-root [filename]",
-  "the root from which all sources are relative"
-);
+  program.option(
+    "-q, --quiet",
+    "Suppress compilation output"
+  );
 
-commander.option(
-  "-o, --out-file [out]",
-  "Compile all input files into a single file"
-);
+  program.option(
+    "-s, --source-maps [true|false|inline|both]",
+    "generate source maps",
+    unstringify
+  );
 
-commander.option(
-  "-d, --out-dir [out]",
-  "Compile an input directory of modules into an output directory"
-);
+  program.option(
+    "--source-map-target [string]",
+    "set `file` on returned source map"
+  );
 
-commander.option(
-  "-D, --copy-files",
-  "When compiling a directory copy over non-compilable files"
-);
-commander.option(
-  "--include-dotfiles",
-  "Include dotfiles when compiling and copying non-compilable files"
-);
+  program.option(
+    "--source-file-name [string]",
+    "set `sources[0]` on returned source map"
+  );
 
-commander.option(
-  "-C, --config <config>",
-  "Override a config from .swcrc file. e.g. -C module.type=amd -C module.moduleId=hello",
-  collect
-);
+  program.option(
+    "--source-root [filename]",
+    "the root from which all sources are relative"
+  );
 
-commander.option(
-  "--sync",
-  "Invoke swc synchronously. Useful for debugging.",
-  collect
-);
+  program.option(
+    "-o, --out-file [out]",
+    "Compile all input files into a single file"
+  );
 
-commander.option(
-  "--log-watch-compilation",
-  "Log a message when a watched file is successfully compiled",
-  true
-);
+  program.option(
+    "-d, --out-dir [out]",
+    "Compile an input directory of modules into an output directory"
+  );
 
-commander.option(
-  "--extensions [list]",
-  "Use specific extensions",
-  collect
-);
+  program.option(
+    "-D, --copy-files",
+    "When compiling a directory copy over non-compilable files"
+  );
+  program.option(
+    "--include-dotfiles",
+    "Include dotfiles when compiling and copying non-compilable files"
+  );
 
-commander.version(`
+  program.option(
+    "-C, --config <config>",
+    "Override a config from .swcrc file. e.g. -C module.type=amd -C module.moduleId=hello",
+    collect
+  );
+
+  program.option(
+    "--sync",
+    "Invoke swc synchronously. Useful for debugging.",
+    collect
+  );
+
+  program.option(
+    "--log-watch-compilation",
+    "Log a message when a watched file is successfully compiled",
+    true
+  );
+
+  program.option(
+    "--extensions [list]",
+    "Use specific extensions",
+    collect
+  );
+
+  program.version(`
 @swc/cli: ${pkg.version}
 @swc/core: ${swcCoreVersion}
 `);
 
-commander.usage("[options] <files ...>");
+  program.usage("[options] <files ...>");
+}
 
 function unstringify(val: string): any {
   try {
@@ -133,6 +145,7 @@ function unstringify(val: string): any {
 
 function collect(value: string, previousValue?: string[]): string[] | undefined {
   // If the user passed the option with no value, like "babel file.js --presets", do nothing.
+  /* istanbul ignore next */
   if (typeof value !== "string") return previousValue;
 
   const values = value.split(",");
@@ -159,10 +172,10 @@ export interface CliOptions {
 }
 
 export default function parserArgs(args: string[]) {
-  commander.parse(args);
-  const opts = commander.opts();
+  program.parse(args);
+  const opts = program.opts();
 
-  const filenames = commander.args;
+  const filenames = program.args;
   const errors = [];
 
   if (opts.outDir && !filenames.length) {


### PR DESCRIPTION
#45

This fixes a regression that broke `--config foo.bar`.

Bonus:
- Small refactor of `options.ts` to facilitate testing
- ~Corrects the interface for `CliOptions`~
- 100% coverage (not full tests) for `options.ts`