### PR TITLE
Define --env option.

### DIFF
--- a/src/spack/options.ts
+++ b/src/spack/options.ts
@@ -10,6 +10,7 @@ export interface SpackCliOptions {
 }
 
 commander.option("--config [path]", "Path to a spack.config.js file to use.");
+commander.option("--env [name=value...]", "Set environment variable(s).");
 // TODO: allow using ts. See: https://github.com/swc-project/swc/issues/841
 
 commander.option("--mode <development | production | none>", "Mode to use");
@@ -175,6 +176,15 @@ export default async function parseSpackArgs(args: string[]): Promise<{
     const configOpts: BundleOptions = await compileBundleOptions(opts.config ?? path.resolve('spack.config.js')) as any;
     if (opts.entry) {
         configOpts.entry = opts.entry;
+    }
+    if (opts.env) {
+        configOpts.env = configOpts.env || {};
+        const envArgs = opts.env.reduce((o, pair) => {
+          const [key, value] = pair.split("=");
+          o[key] = value || '';
+          return o;
+        }, {});
+        Object.assign(configOpts.env, envArgs);
     }
     if (opts.mode) {
         configOpts.mode = opts.mode;

--- a/src/spack/options.ts
+++ b/src/spack/options.ts
@@ -180,7 +180,7 @@ export default async function parseSpackArgs(args: string[]): Promise<{
     }
     if (opts.env) {
         configOpts.env = configOpts.env || {};
-        const envArgs = opts.env.reduce((o, pair) => {
+        const envArgs = opts.env.reduce((o: { [name: string]: string }, pair: string) => {
           const [key, value] = pair.split("=");
           o[key] = value || '';
           return o;


### PR DESCRIPTION
Merge arguments with the existing value in BundleOptions so that CLI
args will overwrite or append to `env` set in `spack.config.js`.

See https://github.com/swc-project/swc/issues/2087.