### PR TITLE
Fix `--no-swcrc` to work with files

### DIFF
--- a/src/swc/__tests__/options.test.ts
+++ b/src/swc/__tests__/options.test.ts
@@ -31,7 +31,8 @@ const createDefaultResult = (): ParserArgsReturn => ({
     "jsc": { "parser": undefined, "transform": {} },
     "sourceFileName": undefined,
     "sourceMaps": undefined,
-    "sourceRoot": undefined
+    "sourceRoot": undefined,
+    "swcrc": true
   }
 })
 

--- a/src/swc/options.ts
+++ b/src/swc/options.ts
@@ -224,7 +224,8 @@ export default function parserArgs(args: string[]) {
     sourceMaps: opts.sourceMaps,
     sourceFileName: opts.sourceFileName,
     sourceRoot: opts.sourceRoot,
-    configFile: opts.configFile
+    configFile: opts.configFile,
+    swcrc: opts.swcrc
   };
 
   if (opts.config) {


### PR DESCRIPTION
The cli does not pass `swcrc: boolean` option to `@swc/core`