### PR TITLE
Don't output source maps if sourceMaps option is omitted or false

### DIFF
--- a/src/swc/compile.ts
+++ b/src/swc/compile.ts
@@ -11,7 +11,7 @@ const {
 } = promises;
 
 function withSourceMap(output: Output, options: Options, destFile: string, destDir: string) {
-  if (!output.map || options.sourceMaps === "inline") {
+  if (!output.map || !options.sourceMaps || options.sourceMaps === "inline") {
     return {
       sourceCode: output.code,
     }

--- a/src/swc/util.ts
+++ b/src/swc/util.ts
@@ -68,13 +68,13 @@ export async function compile(
 export function outputFile(
   output: swc.Output,
   filename: string,
-  sourceMaps: undefined | swc.Options['sourceMaps']
+  sourceMaps: swc.Options['sourceMaps']
 ) {
   const destDir = dirname(filename);
   mkdirSync(destDir, { recursive: true });
 
   let code = output.code;
-  if (output.map && sourceMaps !== "inline") {
+  if (output.map && sourceMaps && sourceMaps !== "inline") {
     // we've requested for a sourcemap to be written to disk
     const fileDirName = dirname(filename);
     const mapLoc = filename + ".map";


### PR DESCRIPTION
Closes #73 

Reverts regression in #68