### PR TITLE
Nested src dir shows up in out dir #108

### DIFF
--- a/src/swc/__tests__/sources.test.ts
+++ b/src/swc/__tests__/sources.test.ts
@@ -11,14 +11,14 @@ describe("globSources", () => {
   });
 
   it("exclude dotfiles sources when includeDotfiles=false", async () => {
-    const files = await globSources([".dotfile"], false);
+    const [files, _] = await globSources([".dotfile"], false);
 
     expect([...files]).toEqual([]);
   });
 
   it("include dotfiles sources when includeDotfiles=true", async () => {
     (fs as any).setMockStats({ ".dotfile": { isDirectory: () => false } });
-    const files = await globSources([".dotfile"], true);
+    const [files, _] = await globSources([".dotfile"], true);
 
     expect([...files]).toEqual([".dotfile"]);
   });
@@ -26,7 +26,7 @@ describe("globSources", () => {
   it("include multiple file sources", async () => {
     (fs as any).setMockStats({ ".dotfile": { isDirectory: () => false } });
     (fs as any).setMockStats({ file: { isDirectory: () => false } });
-    const files = await globSources([".dotfile", "file"], true);
+    const [files, _] = await globSources([".dotfile", "file"], true);
 
     expect([...files]).toEqual([".dotfile", "file"]);
   });
@@ -34,7 +34,7 @@ describe("globSources", () => {
   it("exclude files that errors on stats", async () => {
     (fs as any).setMockStats({ ".dotfile": { isDirectory: () => false } });
     (fs as any).setMockStats({ file: new Error("Failed stat") });
-    const files = await globSources([".dotfile", "file"], true);
+    const [files, _] = await globSources([".dotfile", "file"], true);
 
     expect([...files]).toEqual([".dotfile"]);
   });
@@ -44,7 +44,7 @@ describe("globSources", () => {
     (fs as any).setMockStats({ file: { isDirectory: () => false } });
 
     (glob as unknown as jest.Mock).mockResolvedValue(["fileDir1", "fileDir2"]);
-    const files = await globSources(["file", "directory"], true);
+    const [files, _] = await globSources(["file", "directory"], true);
 
     expect([...files]).toEqual(["file", "fileDir1", "fileDir2"]);
   });
@@ -54,7 +54,7 @@ describe("globSources", () => {
     (fs as any).setMockStats({ file: { isDirectory: () => false } });
 
     (glob as unknown as jest.Mock).mockRejectedValue(new Error("Failed"));
-    const files = await globSources(["file", "directory"], true);
+    const [files, _] = await globSources(["file", "directory"], true);
 
     expect([...files]).toEqual(["file"]);
   });

--- a/src/swc/file.ts
+++ b/src/swc/file.ts
@@ -7,6 +7,15 @@ import { CliOptions } from "./options";
 import { globSources, isCompilableExtension, watchSources } from "./sources";
 import * as util from "./util";
 
+// export interface File {
+//   filename: string;
+//   sourceLength: number;
+// }
+
+export interface FileContext {
+  [filename: string]: number;
+}
+
 export default async function ({
   cliOptions,
   swcOptions,
@@ -107,10 +116,11 @@ export default async function ({
   ) {
     const results: typeof previousResults = new Map();
 
-    for (const filename of await globSources(
+    const [filenames, _] = await globSources(
       cliOptions.filenames,
       cliOptions.includeDotfiles
-    )) {
+    );
+    for (const filename of filenames) {
       if (isCompilableExtension(filename, cliOptions.extensions)) {
         results.set(filename, previousResults.get(filename)!);
       }

--- a/src/swc/index.ts
+++ b/src/swc/index.ts
@@ -2,7 +2,7 @@ import dirCommand from "./dir";
 import fileCommand from "./file";
 import parseArgs, { initProgram } from "./options";
 
-initProgram()
+initProgram();
 const opts = parseArgs(process.argv);
 const fn = opts.cliOptions.outDir ? dirCommand : fileCommand;
 

--- a/src/swc/options.ts
+++ b/src/swc/options.ts
@@ -19,6 +19,8 @@ export const initProgram = () => {
     "filename to use when reading from stdin - this will be used in source-maps, errors etc"
   );
 
+  program.option("--cwd [path]", "Specify the current working directory");
+
   program.option("--config-file [path]", "Path to a .swcrc file to use");
 
   program.option(
@@ -140,6 +142,7 @@ function collect(
 }
 
 export interface CliOptions {
+  readonly cwd: string;
   readonly outDir: string;
   readonly outFile: string;
   /**
@@ -246,6 +249,7 @@ export default function parserArgs(args: string[]) {
   }
 
   const cliOptions: CliOptions = {
+    cwd: opts.cwd,
     outDir: opts.outDir,
     outFile: opts.outFile,
     filename: opts.filename,


### PR DESCRIPTION
* Relative path support in CLI
  * Let's convert the user input paths to the absolute paths
  * **As-Is**: We had to use `$PWD` to point out the current directory
  * **To-Be** we can use the relative path. Dot notation is supported.
  `swc ../../src --out-dir dist`
  * `filenames` and `outDir` which are passed by arguments will be checked and converted to the absolute paths.
  `const filenamesAbsolutePath = absolutePath(filenames, cwd);`
  `const outDirAbsolutePath = slash(resolve(cwd, outDir));`
  * This will resolve the issue #2210

* Source directory layout will be maintained to the output directory. So #108 will be resolved.
  * **As-Is**: Source directory information which is typed in by the user is vanished on the process. But this information is important to maintain the output directory layout. When user typed in the source directory, it is substituted to all filenames by globSources(). We had only filenames. So we couldn't reorganize the output directory layout without the source directory information. 
  * **To-Be**: We record the user input part in filename. I added File interface for this purpose. `File.sourceLength` is the index of the user input's end(source directory length) in filename. I add Number type in File interface to minimize the memory consumption and the fast process using slice() function. 
  * From the absolute path of file, we eliminate the source directory part. Then we have a relative path. We can combine this relative path to the absolute path of destination that is specified by '--out-dir' argument. Now we can reconstruct the output directory layout.
  * I tried to not to change any CLI interface which is supported now. 

And I think this will resolve the issue #2092 too.

