### PR TITLE
fix/remove-source-maps-on-unlink

### DIFF
--- a/src/swc/util.ts
+++ b/src/swc/util.ts
@@ -1,7 +1,17 @@
 import * as swc from "@swc/core";
 import slash from "slash";
-import { mkdirSync, writeFileSync } from "fs";
+import { mkdirSync, writeFileSync, promises } from "fs";
 import { dirname, relative } from "path";
+
+export async function exists(path: string): Promise<boolean> {
+  let pathExists = true;
+  try {
+    await promises.access(path);
+  } catch (err: any) {
+    pathExists = false;
+  }
+  return pathExists;
+}
 
 export async function transform(
   filename: string,


### PR DESCRIPTION
Source maps were not being removed when files were unlinked. This PR adds logic to remove an unlinked file's source map, if it exists.