### PR TITLE
Wait until all bundles are written to disk

### DIFF
--- a/src/spack/index.ts
+++ b/src/spack/index.ts
@@ -37,7 +37,7 @@ const makeDir = promisify(mkdir);
 
         const emitStart = process.hrtime();
         if (spackOptions.output?.path) {
-            await Object.keys(output).map(async (name) => {
+            await Promise.all(Object.keys(output).map(async (name) => {
                 let fullPath = '';
                 if (isUserDefinedEntry(name)) {
                     fullPath = join(spackOptions.output.path, spackOptions.output.name.replace('[name]', name));
@@ -53,7 +53,7 @@ const makeDir = promisify(mkdir);
                 if (output[name].map) {
                     await write(`${fullPath}.map`, output[name].map, 'utf-8')
                 }
-            });
+            }));
         } else {
             throw new Error('Cannot print to stdout: not implemented yet')
         }


### PR DESCRIPTION
After `spack` finishes bundling, it writes the output/bundles to disk. I noticed the time to write the bundles was, in some cases, noticeably less than the duration reported by `time spack`.

Looking at the code, I believe a `Promise.all()` was likely intended, but is missing.