### PR TITLE
feat(swc): move beta announcement to --help

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,9 @@
 See our website [swc-cli][] for more information or the issues associated with this package.
 
 [swc-cli]: https://swc.rs/docs/usage-swc-cli
+
+## @swc/cli@1 beta version is available
+
+Beta version of @swc/cli is now available via `swcx command.
+This'll be a default command for @swc/cli@1.
+Please give it a try and report any issues at https://github.com/swc-project/swc/issues/4017

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "CLI for the swc project",
   "main": "lib/swc/index.js",
   "scripts": {
-    "postinstall": "echo \"Beta version of @swc/cli is now available via 'swcx' command. This'll be a default command for @swc/cli@1. Please give it a try and let us know if there are problems!\"",
     "prepublishOnly": "yarn build && yarn test && yarn types",
     "types": "tsc",
     "types:watch": "tsc --watch",

--- a/src/swc/options.ts
+++ b/src/swc/options.ts
@@ -116,6 +116,17 @@ export const initProgram = () => {
 `);
 
   program.usage("[options] <files ...>");
+  program.addHelpText(
+    "beforeAll",
+    `
+============================================================================================
+Beta version of @swc/cli is now available via 'swcx' command.
+This'll be a default command for @swc/cli@1.
+Please give it a try and report any issues at https://github.com/swc-project/swc/issues/4017
+============================================================================================
+
+`
+  );
 };
 
 function unstringify(val: string): any {


### PR DESCRIPTION
I just learned we can't use postinstall to print messages anymore (https://github.com/npm/cli/issues/3647).

Moving message to `--help` instead. I didn't choose to print out message for default invocation even though this reduces visibility. as swc cli can print output via stdout and new message can corrupt it. Probably we need to update docs  to have better visibility.