### PR TITLE
Handle missing dependencies/devDependencies

### DIFF
--- a/src/swcx/index.ts
+++ b/src/swcx/index.ts
@@ -48,7 +48,7 @@ const getCoreVersion = () => {
           devDependencies,
         } = require(cwdPackageManifestPath);
         const swcCoreVersion =
-          dependencies["@swc/core"] || devDependencies["@swc/core"];
+          dependencies?.["@swc/core"] || devDependencies?.["@swc/core"];
         if (swcCoreVersion) {
           return minVersion(swcCoreVersion);
         }


### PR DESCRIPTION
My `package.json` only has `devDependencies`, resulting in the error:
> Failed to determine swc core version from package.json, using latest available version 1.3.24 instead TypeError: Cannot read properties of undefined (reading '@swc/core')

This PR uses optional chaining to handle this case.