### PR TITLE
fix: bin.path is not a function

### DIFF
--- a/src/swcx/index.ts
+++ b/src/swcx/index.ts
@@ -134,7 +134,7 @@ const executeBinary = async () => {
 
   await bin.run();
 
-  const binPath = bin.path();
+  const binPath = bin.path;
 
   const [, , ...args] = process.argv;
   const options = { cwd: process.cwd(), stdio: "inherit" as StdioOptions };


### PR DESCRIPTION
Hello @kdy1 this pr fix the issue introduced in this one https://github.com/swc-project/cli/pull/194

```
npx swcx --version
TypeError: bin.path is not a function
at node_modules/@swc/cli/lib/swcx/index.js:127:25)
```

the path method is a getter

After correction : 
```
npx swcx --version
SWC 0.91.21
```
