### PR TITLE
feat: add --out-file-extension (with tests)

### DIFF
--- a/src/swc/__tests__/options.test.ts
+++ b/src/swc/__tests__/options.test.ts
@@ -61,6 +61,29 @@ describe("parserArgs", () => {
     expect(result).toEqual(defaultResult);
   });
 
+  describe("--out-file-extension", () => {
+    it("provides the extension in the parsed args", () => {
+      const args = [
+        "node",
+        "/path/to/node_modules/swc-cli/bin/swc.js",
+        "src",
+        "--out-file-extension",
+        "magic_custom_extension",
+      ];
+      const result = parserArgs(args);
+      const expectedOptions = deepmerge(defaultResult, {
+        cliOptions: { outFileExtension: "magic_custom_extension" },
+      });
+      expect(result).toEqual(expectedOptions);
+    });
+
+    it("provides the a sensible default", () => {
+      const args = ["node", "/path/to/node_modules/swc-cli/bin/swc.js", "src"];
+      const result = parserArgs(args);
+      expect(result.cliOptions.outFileExtension).toEqual("js");
+    });
+  });
+
   describe("errors", () => {
     let mockExit: jest.SpyInstance;
     let mockConsoleError: jest.SpyInstance;

--- a/src/swc/__tests__/options.test.ts
+++ b/src/swc/__tests__/options.test.ts
@@ -31,6 +31,7 @@ const createDefaultResult = (): ParserArgsReturn => ({
     outDir: undefined,
     // @ts-expect-error
     outFile: undefined,
+    outFileExtension: "js",
     quiet: false,
     sourceMapTarget: undefined,
     sync: false,

--- a/src/swc/dir.ts
+++ b/src/swc/dir.ts
@@ -56,9 +56,10 @@ async function handleCompile(
   filename: string,
   outDir: string,
   sync: boolean,
-  swcOptions: Options
+  swcOptions: Options,
+  extension: string
 ) {
-  const dest = getDest(filename, outDir, ".js");
+  const dest = getDest(filename, outDir, `.${extension}`);
   const sourceFileName = slash(relative(dirname(dest), filename));
 
   const options = { ...swcOptions, sourceFileName };
@@ -101,6 +102,7 @@ async function initialCompilation(cliOptions: CliOptions, swcOptions: Options) {
     copyFiles,
     extensions,
     outDir,
+    outFileExtension,
     sync,
     quiet,
     watch,
@@ -119,7 +121,13 @@ async function initialCompilation(cliOptions: CliOptions, swcOptions: Options) {
   if (sync) {
     for (const filename of compilable) {
       try {
-        const result = await handleCompile(filename, outDir, sync, swcOptions);
+        const result = await handleCompile(
+          filename,
+          outDir,
+          sync,
+          swcOptions,
+          outFileExtension
+        );
         results.set(filename, result);
       } catch (err: any) {
         console.error(err.message);
@@ -139,10 +147,12 @@ async function initialCompilation(cliOptions: CliOptions, swcOptions: Options) {
     await Promise.all([
       Promise.allSettled(
         compilable.map(file =>
-          handleCompile(file, outDir, sync, swcOptions).catch(err => {
-            console.error(err.message);
-            throw err;
-          })
+          handleCompile(file, outDir, sync, swcOptions, outFileExtension).catch(
+            err => {
+              console.error(err.message);
+              throw err;
+            }
+          )
         )
       ),
       Promise.allSettled(copyable.map(file => handleCopy(file, outDir))),
@@ -224,6 +234,7 @@ async function watchCompilation(cliOptions: CliOptions, swcOptions: Options) {
     copyFiles,
     extensions,
     outDir,
+    outFileExtension,
     quiet,
     sync,
   } = cliOptions;
@@ -261,7 +272,8 @@ async function watchCompilation(cliOptions: CliOptions, swcOptions: Options) {
             filename,
             outDir,
             sync,
-            swcOptions
+            swcOptions,
+            outFileExtension
           );
           if (!quiet && result === CompileStatus.Compiled) {
             const end = process.hrtime(start);

--- a/src/swc/options.ts
+++ b/src/swc/options.ts
@@ -82,6 +82,11 @@ export const initProgram = () => {
   );
 
   program.option(
+    "--out-file-extension [string]",
+    "Use a specific extension for the output files [default: js]"
+  );
+
+  program.option(
     "-D, --copy-files",
     "When compiling a directory copy over non-compilable files"
   );
@@ -163,6 +168,7 @@ export interface CliOptions {
   readonly extensions: string[];
   readonly watch: boolean;
   readonly copyFiles: boolean;
+  readonly outFileExtension: string;
   readonly includeDotfiles: boolean;
   readonly deleteDirOnStart: boolean;
   readonly quiet: boolean;
@@ -266,6 +272,7 @@ export default function parserArgs(args: string[]) {
     extensions: opts.extensions || DEFAULT_EXTENSIONS,
     watch: !!opts.watch,
     copyFiles: !!opts.copyFiles,
+    outFileExtension: opts.outFileExtension || "js",
     includeDotfiles: !!opts.includeDotfiles,
     deleteDirOnStart: Boolean(opts.deleteDirOnStart),
     quiet: !!opts.quiet,


### PR DESCRIPTION
Trying to get some traction on #131 

- Reapply the minimal base changes
- Add tests

This changeset is smaller as it does not reformat the tests to the new/current style, this makes the diff quite large and should probably be done in isolation so as to not muddy the intent of the original PR.

- https://github.com/swc-project/swc/pull/4343
- https://github.com/swc-project/swc/issues/3067