### PR TITLE
Use workers to process files in parallel

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "commander": "^7.1.0",
     "fast-glob": "^3.2.5",
     "minimatch": "^9.0.3",
+    "piscina": "^4.3.0",
     "semver": "^7.3.8",
     "slash": "3.0.0",
     "source-map": "^0.7.3"

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "homepage": "https://github.com/swc-project/cli#readme",
   "engines": {
-    "node": ">= 12.13"
+    "node": ">= 16.14.0"
   },
   "bin": {
     "swc": "./bin/swc.js",
@@ -59,7 +59,7 @@
     "@swc/core": "^1.2.66",
     "@swc/jest": "^0.1.2",
     "@types/jest": "^29.5.0",
-    "@types/node": "^12.19.16",
+    "@types/node": "^20.11.5",
     "@types/semver": "^7.3.13",
     "chokidar": "^3.5.1",
     "deepmerge": "^4.2.2",

--- a/src/spack/index.ts
+++ b/src/spack/index.ts
@@ -56,7 +56,7 @@ const makeDir = promisify(mkdir);
         await makeDir(dirname(fullPath), { recursive: true });
         await write(fullPath, output[name].code, "utf-8");
         if (output[name].map) {
-          await write(`${fullPath}.map`, output[name].map, "utf-8");
+          await write(`${fullPath}.map`, output[name].map!, "utf-8");
         }
       });
     } else {

--- a/src/swc/__tests__/options.test.ts
+++ b/src/swc/__tests__/options.test.ts
@@ -130,6 +130,32 @@ describe("parserArgs", () => {
       expect(mockExit).toHaveBeenCalledWith(2);
       expect(mockConsoleError).toHaveBeenCalledTimes(2);
     });
+
+    it("--workers exits on non-numeric values", async () => {
+      const args = [
+        "node",
+        "/path/to/node_modules/swc-cli/bin/swc.js",
+        "--workers",
+        "not-a-number",
+        "src",
+      ];
+      await parserArgs(args);
+      expect(mockExit).toHaveBeenCalledWith(2);
+      expect(mockConsoleError).toHaveBeenCalledTimes(2);
+    });
+
+    it("--workers exits on non-integer values", async () => {
+      const args = [
+        "node",
+        "/path/to/node_modules/swc-cli/bin/swc.js",
+        "--workers",
+        "1.5",
+        "src",
+      ];
+      await parserArgs(args);
+      expect(mockExit).toHaveBeenCalledWith(2);
+      expect(mockConsoleError).toHaveBeenCalledTimes(2);
+    });
   });
 
   describe("--source-maps", () => {

--- a/src/swc/compile.ts
+++ b/src/swc/compile.ts
@@ -62,7 +62,7 @@ export async function outputResult(
   } else {
     await Promise.all([
       writeFile(destFile, sourceCode, { mode }),
-      writeFile(sourceMapPath, sourceMap, { mode }),
+      writeFile(sourceMapPath, sourceMap!, { mode }),
     ]);
   }
 }

--- a/src/swc/dirWorker.ts
+++ b/src/swc/dirWorker.ts
@@ -1,0 +1,28 @@
+import slash from "slash";
+import { dirname, relative } from "path";
+import { CompileStatus } from "./constants";
+import { compile, getDest } from "./util";
+import { outputResult } from "./compile";
+
+import type { Options } from "@swc/core";
+
+export default async function handleCompile(opts: {
+  filename: string;
+  outDir: string;
+  sync: boolean;
+  swcOptions: Options;
+}) {
+  const dest = getDest(opts.filename, opts.outDir, ".js");
+  const sourceFileName = slash(relative(dirname(dest), opts.filename));
+
+  const options = { ...opts.swcOptions, sourceFileName };
+
+  const result = await compile(opts.filename, options, opts.sync, dest);
+
+  if (result) {
+    await outputResult(result, opts.filename, dest, options);
+    return CompileStatus.Compiled;
+  } else {
+    return CompileStatus.Omitted;
+  }
+}

--- a/src/swc/options.ts
+++ b/src/swc/options.ts
@@ -103,6 +103,11 @@ export const initProgram = () => {
   );
 
   program.option(
+    "--workers [number]",
+    "The number of workers to use for parallel processing"
+  );
+
+  program.option(
     "--log-watch-compilation",
     "Log a message when a watched file is successfully compiled",
     true
@@ -157,6 +162,7 @@ export interface CliOptions {
    * Invoke swc using transformSync. It's useful for debugging.
    */
   readonly sync: boolean;
+  readonly workers: number | undefined;
   readonly sourceMapTarget?: string;
   readonly filename: string;
   readonly filenames: string[];
@@ -205,6 +211,16 @@ export default function parserArgs(args: string[]) {
     errors.push(
       "stdin compilation requires either -f/--filename [filename] or --no-swcrc"
     );
+  }
+
+  let workers: number | undefined;
+  if (opts.workers != null) {
+    workers = parseFloat(opts.workers);
+    if (!Number.isInteger(workers) || workers < 0) {
+      errors.push(
+        "--workers must be a positive integer (found " + opts.workers + ")"
+      );
+    }
   }
 
   if (errors.length) {
@@ -265,6 +281,7 @@ export default function parserArgs(args: string[]) {
     filename: opts.filename,
     filenames,
     sync: !!opts.sync,
+    workers,
     sourceMapTarget: opts.sourceMapTarget,
     extensions: opts.extensions || DEFAULT_EXTENSIONS,
     watch: !!opts.watch,

--- a/src/swc/util.ts
+++ b/src/swc/util.ts
@@ -1,7 +1,7 @@
 import * as swc from "@swc/core";
 import slash from "slash";
 import { mkdirSync, writeFileSync, promises } from "fs";
-import { dirname, relative } from "path";
+import { dirname, join, relative } from "path";
 
 export async function exists(path: string): Promise<boolean> {
   let pathExists = true;
@@ -124,4 +124,29 @@ export function assertCompilationResult<T>(
       `Failed to compile ${failed} ${failed !== 1 ? "files" : "file"} with swc.`
     );
   }
+}
+
+/**
+ * Removes the leading directory, including all parent relative paths
+ */
+function stripComponents(filename: string) {
+  const components = filename.split("/").slice(1);
+  if (!components.length) {
+    return filename;
+  }
+  while (components[0] === "..") {
+    components.shift();
+  }
+  return components.join("/");
+}
+
+const cwd = process.cwd();
+
+export function getDest(filename: string, outDir: string, ext?: string) {
+  const relativePath = slash(relative(cwd, filename));
+  let base = stripComponents(relativePath);
+  if (ext) {
+    base = base.replace(/\.\w*$/, ext);
+  }
+  return join(outDir, base);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2262,6 +2262,24 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
+nice-napi@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/nice-napi/-/nice-napi-1.0.2.tgz#dc0ab5a1eac20ce548802fc5686eaa6bc654927b"
+  integrity sha512-px/KnJAJZf5RuBGcfD+Sp2pAKq0ytz8j+1NehvgIGFkvtvFrDM3T8E4x/JJODXK9WZow8RRGrbA9QQ3hs+pDhA==
+  dependencies:
+    node-addon-api "^3.0.0"
+    node-gyp-build "^4.2.2"
+
+node-addon-api@^3.0.0:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-3.2.1.tgz#81325e0a2117789c0128dab65e7e38f07ceba161"
+  integrity sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==
+
+node-gyp-build@^4.2.2:
+  version "4.8.0"
+  resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.8.0.tgz#3fee9c1731df4581a3f9ead74664369ff00d26dd"
+  integrity sha512-u6fs2AEUljNho3EYTJNBfImO5QTo/J/1Etd+NVdCj7qWKUSN/bSLkZwhDv7I+w/MSC6qJ4cknepkAYykDdK8og==
+
 node-int64@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
@@ -2412,6 +2430,13 @@ pirates@^4.0.4:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/pirates/-/pirates-4.0.5.tgz#feec352ea5c3268fb23a37c702ab1699f35a5f3b"
   integrity sha512-8V9+HQPupnaXMA23c5hvl69zXvTwTzyAYasnkb0Tts4XvO4CliqONMOnvlq26rkhLC3nWDFBJf73LU1e1VZLaQ==
+
+piscina@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/piscina/-/piscina-4.3.0.tgz#fd219f507d410c61dbfb9bd4155c1f19eddb8535"
+  integrity sha512-vTQszGZj78p0BHFNO/cSvpzPUYa4tLXRe30aIYyQjqRS3fK/kPqdxvkTfGXQlEpWOI+mOOkda0iEY6NaanLWJA==
+  optionalDependencies:
+    nice-napi "^1.0.2"
 
 pkg-dir@^4.2.0:
   version "4.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -795,10 +795,12 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.15.3.tgz#f0b991c32cfc6a4e7f3399d6cb4b8cf9a0315014"
   integrity sha512-p6ua9zBxz5otCmbpb5D3U4B5Nanw6Pk3PPyX05xnxbB/fRv71N7CPmORg7uAD5P70T0xmx1pzAx/FUfa5X+3cw==
 
-"@types/node@^12.19.16":
-  version "12.20.55"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.55.tgz#c329cbd434c42164f846b909bd6f85b5537f6240"
-  integrity sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==
+"@types/node@^20.11.5":
+  version "20.11.5"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.11.5.tgz#be10c622ca7fcaa3cf226cf80166abc31389d86e"
+  integrity sha512-g557vgQjUUfN76MZAN/dt1z3dzcUsimuysco0KeluHgrPdJXkP/XdAURgyO2W9fZWHRtRBiVKzKn8vyOAwlG+w==
+  dependencies:
+    undici-types "~5.26.4"
 
 "@types/prettier@^2.1.5":
   version "2.7.2"
@@ -2827,6 +2829,11 @@ typescript@~4.3.2:
   version "4.3.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.5.tgz#4d1c37cc16e893973c45a06886b7113234f119f4"
   integrity sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==
+
+undici-types@~5.26.4:
+  version "5.26.5"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.26.5.tgz#bcd539893d00b56e964fd2657a4866b221a65617"
+  integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
 
 update-browserslist-db@^1.0.10:
   version "1.0.10"


### PR DESCRIPTION
This PR adds a worker pool to process files in parallel.

## Notes
The `piscina` typings reference [`EventEmitterAsyncResource`](https://nodejs.org/api/events.html#class-eventseventemitterasyncresource-extends-eventemitter), which was added in Node 16.14.0 but (apparently) wasn't exposed  by `@types/node` until `20.x.x`. I bumped `@types/node` and increased the `engines` check to `16.x`, which feels reasonable given that Node 18 is already in maintenance and the current LTS is 20.x.x ([docs](https://nodejs.org/en/about/previous-releases)). Not sure if you're willing to take that change or not. 

## Results 
Here's the command I'm running to compare performance. We're currently using SWC for minification at the last stage of a build pipeline, so this test primarily reflects that use case. The `fixtures` directory here contains ~2400 JavaScript files.

```bash
time ../swc-cli/bin/swc.js --out-dir build/swc-cli -C minify=true -C jsc.minify.compress=true -C jsc.minify.mangle=true fixtures/**/*.js
```

Description  |  Time
-- | --
With `--sync` (before this PR) | 3:35.69
Without `--sync` (before this PR) | 2:36.66
With `--workers` (after this PR) | 1:18.58

As a sidenote, I was a little surprised that this is still meaningfully slower than replacing `transformFile()` with `minify()` (better emulating the custom code we're using internally at the moment). I'm not really familiar with SWCs implementation, so I'm not sure whether I _should_ be surprised by this or not. 

Description  |  Time
-- | --
Replace `transformFile()` with `minify()` and `--sync` | 43.552
Replace `transformFile()` with `minify()` without `--sync` | 15.475
Replace `transformFile()` with `minify()` and add `--workers` | 17.399

The [minification docs](https://swc.rs/docs/configuration/minification) imply that it's appropriate to run the CLI for minification like this. Maybe a dedicated `minify` command might make sense?

Fixes https://github.com/swc-project/cli/issues/274