### PR TITLE
feat: Add `strip-leading-paths` option

### DIFF
--- a/src/swc/__tests__/options.test.ts
+++ b/src/swc/__tests__/options.test.ts
@@ -35,6 +35,7 @@ const createDefaultResult = (): ParserArgsReturn => ({
     outFile: undefined,
     quiet: false,
     sourceMapTarget: undefined,
+    stripLeadingPaths: false,
     sync: false,
     watch: false,
   },
@@ -206,6 +207,14 @@ describe("parserArgs", () => {
 
   describe("--config", () => {
     it("throws with no config", async () => {
+      let mockConsoleError: jest.SpyInstance;
+
+      mockConsoleError = jest
+        .spyOn(process.stderr, "write")
+        .mockImplementation(() => {
+          return true;
+        });
+
       const args = [
         "node",
         "/path/to/node_modules/swc-cli/bin/swc.js",
@@ -213,6 +222,8 @@ describe("parserArgs", () => {
         "-C",
       ];
       expect(() => parserArgs(args)).toThrow();
+
+      mockConsoleError.mockRestore();
     });
 
     it("react development", async () => {

--- a/src/swc/__tests__/util.test.ts
+++ b/src/swc/__tests__/util.test.ts
@@ -1,0 +1,22 @@
+import { join } from "path";
+import { getDest } from "../util";
+
+describe("getDest", () => {
+  it("does not modify the filename by default", () => {
+    expect(
+      getDest(join(process.cwd(), "src/path/name.ts"), "foo/bar", false)
+    ).toEqual("foo/bar/src/path/name.ts");
+  });
+
+  it("when stripLeadingPaths is true, it removes leading paths", () => {
+    expect(
+      getDest(join(process.cwd(), "src/path/name.ts"), "foo/bar", true)
+    ).toEqual("foo/bar/path/name.ts");
+  });
+
+  it("when stripLeadingPaths is true, it also resolves relative paths", () => {
+    expect(
+      getDest(join(process.cwd(), "../../path/name.ts"), "foo/bar", true)
+    ).toEqual("foo/bar/path/name.ts");
+  });
+});

--- a/src/swc/dirWorker.ts
+++ b/src/swc/dirWorker.ts
@@ -5,14 +5,21 @@ import { compile, getDest } from "./util";
 import { outputResult } from "./compile";
 
 import type { Options } from "@swc/core";
+import type { CliOptions } from "./options";
 
 export default async function handleCompile(opts: {
   filename: string;
   outDir: string;
   sync: boolean;
+  cliOptions: CliOptions;
   swcOptions: Options;
 }) {
-  const dest = getDest(opts.filename, opts.outDir, ".js");
+  const dest = getDest(
+    opts.filename,
+    opts.outDir,
+    opts.cliOptions.stripLeadingPaths,
+    ".js"
+  );
   const sourceFileName = slash(relative(dirname(dest), opts.filename));
 
   const options = { ...opts.swcOptions, sourceFileName };

--- a/src/swc/options.ts
+++ b/src/swc/options.ts
@@ -85,6 +85,12 @@ export const initProgram = () => {
     "-D, --copy-files",
     "When compiling a directory copy over non-compilable files"
   );
+
+  program.option(
+    "--strip-leading-paths",
+    "Remove the leading directory (including all parent relative paths) when building the final output path"
+  );
+
   program.option(
     "--include-dotfiles",
     "Include dotfiles when compiling and copying non-compilable files"
@@ -158,6 +164,7 @@ function collect(
 export interface CliOptions {
   readonly outDir: string;
   readonly outFile: string;
+  readonly stripLeadingPaths: boolean;
   /**
    * Invoke swc using transformSync. It's useful for debugging.
    */
@@ -278,6 +285,7 @@ export default function parserArgs(args: string[]) {
   const cliOptions: CliOptions = {
     outDir: opts.outDir,
     outFile: opts.outFile,
+    stripLeadingPaths: Boolean(opts.stripLeadingPaths),
     filename: opts.filename,
     filenames,
     sync: !!opts.sync,

--- a/src/swc/util.ts
+++ b/src/swc/util.ts
@@ -126,10 +126,29 @@ export function assertCompilationResult<T>(
   }
 }
 
+function stripComponents(filename: string) {
+  const components = filename.split("/").slice(1);
+  if (!components.length) {
+    return filename;
+  }
+  while (components[0] === "..") {
+    components.shift();
+  }
+  return components.join("/");
+}
+
 const cwd = process.cwd();
 
-export function getDest(filename: string, outDir: string, ext?: string) {
+export function getDest(
+  filename: string,
+  outDir: string,
+  stripLeadingPaths: boolean,
+  ext?: string
+) {
   let base = slash(relative(cwd, filename));
+  if (stripLeadingPaths) {
+    base = stripComponents(base);
+  }
   if (ext) {
     base = base.replace(/\.\w*$/, ext);
   }


### PR DESCRIPTION
This PR adds an option to revert the previous behavior of `0.2.x` where leading paths were stripped when building the destination path.

Fixes #281.