### PR TITLE
fix: `.undefined` file extension when interacting with `dir` directly

### DIFF
--- a/src/swc/__tests__/dirWorker.test.ts
+++ b/src/swc/__tests__/dirWorker.test.ts
@@ -1,0 +1,82 @@
+import { Options } from "@swc/core";
+import handleCompile from "../dirWorker";
+import { CliOptions, DEFAULT_OUT_FILE_EXTENSION } from "../options";
+import * as utilModule from '../util';
+
+type HandleCompileOptions = {
+  cliOptions: CliOptions;
+  swcOptions: Options;
+  sync: false,
+  outDir: "outDir",
+  filename: string,
+  outFileExtension?: string;
+}
+
+const createHandleCompileOptions = (options?: Partial<HandleCompileOptions>): HandleCompileOptions => ({
+  cliOptions: {
+    outDir: "",
+    outFile: "",
+    filename: "",
+    stripLeadingPaths: false,
+    filenames: [],
+    sync: false,
+    workers: undefined,
+    sourceMapTarget: undefined,
+    extensions: [],
+    watch: false,
+    copyFiles: false,
+    outFileExtension: "",
+    includeDotfiles: false,
+    deleteDirOnStart: false,
+    quiet: true,
+    only: [],
+    ignore: [],
+  },
+  swcOptions: {},
+  sync: false,
+  outDir: "outDir",
+  filename: "",
+  ...options,
+});
+
+jest.mock('../util', () => ({
+  ...jest.requireActual("../util"),
+  compile: jest.fn(),
+}));
+
+describe("dirWorker", () => {
+  it('should call "compile" with the "DEFAULT_OUT_FILE_EXTENSION" when "outFileExtension" is undefined', async () => {
+    const filename = 'test';
+    const options = createHandleCompileOptions({
+      filename: `${filename}.ts`
+    });
+
+    try {
+      await handleCompile(options);
+    } catch (err) {
+      // We don't care about the error in this test, we want to make sure that "compile" was called
+    }
+
+    // Assert that subFunction was called with the correct parameter
+    expect(utilModule.compile).toHaveBeenCalledWith(options.filename, { sourceFileName: `../${options.filename}`}, options.sync, `${options.outDir}/${filename}.${DEFAULT_OUT_FILE_EXTENSION}`);
+  });
+});
+
+describe("dirWorker", () => {
+  it('should call "compile" with "outFileExtension" when undefined', async () => {
+    const filename = 'test';
+    const options = createHandleCompileOptions({
+      filename: `${filename}.ts`,
+      outFileExtension: 'cjs'
+    });
+
+    try {
+      await handleCompile(options);
+    } catch (err) {
+      // We don't care about the error in this test, we want to make sure that "compile" was called
+    }
+
+    // Assert that subFunction was called with the correct parameter
+    expect(utilModule.compile).toHaveBeenCalledWith(options.filename, { sourceFileName: `../${options.filename}`}, options.sync, `${options.outDir}/${filename}.${options.outFileExtension}`);
+  });
+});

--- a/src/swc/__tests__/options.test.ts
+++ b/src/swc/__tests__/options.test.ts
@@ -80,7 +80,7 @@ describe("parserArgs", () => {
       expect(result).toEqual(expectedOptions);
     });
 
-    it("provides the a sensible default", () => {
+    it("provides a sensible default", () => {
       const args = ["node", "/path/to/node_modules/swc-cli/bin/swc.js", "src"];
       const result = parserArgs(args);
       expect(result.cliOptions.outFileExtension).toEqual("js");

--- a/src/swc/dirWorker.ts
+++ b/src/swc/dirWorker.ts
@@ -6,6 +6,7 @@ import { outputResult } from "./compile";
 
 import type { Options } from "@swc/core";
 import type { CliOptions } from "./options";
+import { DEFAULT_OUT_FILE_EXTENSION } from "./options";
 
 export default async function handleCompile(opts: {
   filename: string;
@@ -13,13 +14,13 @@ export default async function handleCompile(opts: {
   sync: boolean;
   cliOptions: CliOptions;
   swcOptions: Options;
-  outFileExtension: string;
+  outFileExtension?: string;
 }) {
   const dest = getDest(
     opts.filename,
     opts.outDir,
     opts.cliOptions.stripLeadingPaths,
-    `.${opts.outFileExtension}`
+    `.${opts.outFileExtension ?? DEFAULT_OUT_FILE_EXTENSION}`
   );
   const sourceFileName = slash(relative(dirname(dest), opts.filename));
 

--- a/src/swc/options.ts
+++ b/src/swc/options.ts
@@ -5,6 +5,7 @@ import type { Options } from "@swc/core";
 const pkg = require("../../package.json");
 
 let program: commander.Command;
+export const DEFAULT_OUT_FILE_EXTENSION = "js";
 
 export const initProgram = () => {
   program = new commander.Command();
@@ -84,7 +85,7 @@ export const initProgram = () => {
   program.option(
     "--out-file-extension [string]",
     "Use a specific extension for the output files [default: js]",
-    "js"
+    DEFAULT_OUT_FILE_EXTENSION,
   );
 
   program.option(
@@ -302,7 +303,7 @@ export default function parserArgs(args: string[]) {
     extensions: opts.extensions || DEFAULT_EXTENSIONS,
     watch: !!opts.watch,
     copyFiles: !!opts.copyFiles,
-    outFileExtension: opts.outFileExtension || "js",
+    outFileExtension: opts.outFileExtension || DEFAULT_OUT_FILE_EXTENSION,
     includeDotfiles: !!opts.includeDotfiles,
     deleteDirOnStart: Boolean(opts.deleteDirOnStart),
     quiet: !!opts.quiet,


### PR DESCRIPTION
Starting with `v0.3.3` if `dir.ts` is called directly, like many consumers do, we would experience the `.undefined` file extension issue. (#287).

This is because prior `v0.3.3` the default extension was stored inside `dir.ts`. So even though we have the defaults in `options.ts` it will never reach `dir.ts`.

I see it as breaking change so this PR creates a constant (`DEFAULT_OUT_FILE_EXTENSION`) close to the options, that can also be used in `dir.ts`.

The changes were tested through manual and automated tests (`yarn test`).